### PR TITLE
Changing service time.

### DIFF
--- a/ciw/data_record.py
+++ b/ciw/data_record.py
@@ -6,7 +6,7 @@ class DataRecord(object):
     """
     def __init__(self,
                 arrival_date,
-                service_time,
+                service_end_date,
                 service_start_date,
                 exit_date,
                 node,
@@ -18,13 +18,13 @@ class DataRecord(object):
         Initialises a data record instance.
         """
         self.arrival_date = arrival_date
-        self.service_time = service_time
+        self.service_time = service_end_date - service_start_date
         self.service_start_date = service_start_date
         self.exit_date = exit_date
         self.customer_class = customer_class
         self.queue_size_at_arrival = queue_size_at_arrival
         self.queue_size_at_departure = queue_size_at_departure
-        self.service_end_date = self.service_start_date + self.service_time
+        self.service_end_date = service_end_date
         self.wait = self.service_start_date - self.arrival_date
         self.blocked = self.exit_date - self.service_end_date
         self.node = node

--- a/ciw/node.py
+++ b/ciw/node.py
@@ -381,7 +381,7 @@ class Node(object):
             - Queue size at departure
         """
         record = DataRecord(individual.arrival_date,
-                            individual.service_time,
+                            individual.service_end_date,
                             individual.service_start_date,
                             individual.exit_date,
                             self.id_number,

--- a/ciw/tests/test_data_record.py
+++ b/ciw/tests/test_data_record.py
@@ -6,7 +6,7 @@ from hypothesis.strategies import floats, integers
 class TestDataRecord(unittest.TestCase):
 
     def test_init_method(self):
-        r = ciw.DataRecord(2, 3, 2, 8, 1, 1, 2, 0, 3)
+        r = ciw.DataRecord(2, 5, 2, 8, 1, 1, 2, 0, 3)
         self.assertEqual(r.arrival_date, 2)
         self.assertEqual(r.wait, 0)
         self.assertEqual(r.service_start_date, 2)
@@ -21,11 +21,11 @@ class TestDataRecord(unittest.TestCase):
         self.assertEqual(r.queue_size_at_departure, 3)
         self.assertEqual(str(r), 'Data Record')
 
-        r = ciw.DataRecord(5.7, 2.1, 8.2, 10.3, 1, -1, 3, 32, 21)
+        r = ciw.DataRecord(5.7, 10.3, 8.2, 10.3, 1, -1, 3, 32, 21)
         self.assertEqual(r.arrival_date, 5.7)
         self.assertEqual(round(r.wait, 1), 2.5)
         self.assertEqual(r.service_start_date, 8.2)
-        self.assertEqual(r.service_time, 2.1)
+        self.assertEqual(round(r.service_time, 1), 2.1)
         self.assertEqual(round(r.service_end_date, 1), 10.3)
         self.assertEqual(round(r.blocked, 1), 0.0)
         self.assertEqual(r.exit_date, 10.3)
@@ -57,9 +57,10 @@ class TestDataRecord(unittest.TestCase):
                           queue_size_at_departure):
         # Define parameters
         service_start_date = arrival_date + inter_service_start_date
+        service_end_date = service_time + service_start_date
         exit_date = service_start_date + inter_exit_date + service_time
         r = ciw.DataRecord(arrival_date,
-                           service_time,
+                           service_end_date,
                            service_start_date,
                            exit_date,
                            node,
@@ -72,8 +73,8 @@ class TestDataRecord(unittest.TestCase):
         self.assertEqual(r.arrival_date, arrival_date)
         self.assertEqual(r.wait, service_start_date - arrival_date)
         self.assertEqual(r.service_start_date, service_start_date)
-        self.assertEqual(r.service_time, service_time)
-        self.assertEqual(r.service_end_date, service_start_date + service_time)
+        self.assertEqual(r.service_time, service_end_date - service_start_date)
+        self.assertEqual(r.service_end_date, service_end_date)
         self.assertEqual(r.blocked, exit_date - (service_time + service_start_date))
         self.assertEqual(r.exit_date, exit_date)
         self.assertEqual(r.node, node)

--- a/ciw/tests/test_node.py
+++ b/ciw/tests/test_node.py
@@ -557,14 +557,15 @@ class TestNode(unittest.TestCase):
         ind = ciw.Individual(6)
         N.accept(ind, 3)
         ind.service_start_date = 3.5
+        ind.service_end_date = 5.5
         ind.exit_date = 9
         N.write_individual_record(ind)
         self.assertEqual(ind.data_records[0].arrival_date, 3)
         self.assertEqual(ind.data_records[0].wait, 0.5)
         self.assertEqual(ind.data_records[0].service_start_date, 3.5)
-        self.assertEqual(round(ind.data_records[0].service_time, 5), 0.07894)
-        self.assertEqual(round(ind.data_records[0].service_end_date, 5), 3.57894)
-        self.assertEqual(round(ind.data_records[0].blocked, 5), 5.42106)
+        self.assertEqual(ind.data_records[0].service_time, 2)
+        self.assertEqual(ind.data_records[0].service_end_date, 5.5)
+        self.assertEqual(ind.data_records[0].blocked, 3.5)
         self.assertEqual(ind.data_records[0].exit_date, 9)
         self.assertEqual(ind.data_records[0].customer_class, 0)
 
@@ -639,4 +640,3 @@ class TestNode(unittest.TestCase):
         self.assertEqual([str(obs) for obs in N1.all_individuals], ['Individual 1', 'Individual 2'])
         self.assertEqual([[str(obs) for obs in lst] for lst in N2.individuals], [['Individual 3'], ['Individual 4']])
         self.assertEqual([str(obs) for obs in N2.all_individuals], ['Individual 3', 'Individual 4'])
-


### PR DESCRIPTION
The previous service time was calculated by using a sample number,
that has been changed to be calculated as ending time minus the
starting time.

In the nodes parameters we are no longer passing the service time,
but the end date service to calculate the service time.

The test had to be altered as well.