### PR TITLE
Improve ciw.random_choice

### DIFF
--- a/ciw/auxiliary.py
+++ b/ciw/auxiliary.py
@@ -18,8 +18,7 @@ def random_choice(array, probs=None):
 	"""
 	# If no pdf provided, assume uniform dist:
 	if probs == None:
-		lenarr = len(array)
-		probs = [1.0/lenarr for _ in range(lenarr)]
+		return array[int(random.random() * len(array))]
 
 	# A common case, guaranteed to reach the Exit node;
 	# No need to sample for this:

--- a/ciw/tests/test_simulation.py
+++ b/ciw/tests/test_simulation.py
@@ -3,7 +3,6 @@ import ciw
 from hypothesis import given
 from hypothesis.strategies import floats, integers, random_module
 import os
-from numpy import mean
 from decimal import Decimal
 import networkx as nx
 import csv
@@ -573,13 +572,15 @@ class TestSimulation(unittest.TestCase):
             Q = ciw.Simulation(ciw.create_network(params_dict))
             Q.simulate_until_max_time(400)
             recs = Q.get_all_records()
-            throughput_class0.append(mean([r.waiting_time + r.service_time for
-                r in recs if r.customer_class==0 if r.arrival_date > 100]))
-            throughput_class1.append(mean([r.waiting_time + r.service_time for
-                r in recs if r.customer_class==1 if r.arrival_date > 100]))
+            throughput_c0 = [r.waiting_time + r.service_time for
+                r in recs if r.customer_class==0 if r.arrival_date > 100]
+            throughput_c1 = [r.waiting_time + r.service_time for
+                r in recs if r.customer_class==1 if r.arrival_date > 100]
+            throughput_class0.append(sum(throughput_c0)/len(throughput_c0))
+            throughput_class1.append(sum(throughput_c1)/len(throughput_c1))
 
-        self.assertEqual(round(mean(throughput_class0), 5), 1.94852)
-        self.assertEqual(round(mean(throughput_class1), 5), 5.92823)
+        self.assertEqual(round(sum(throughput_class0)/80.0, 5), 1.94852)
+        self.assertEqual(round(sum(throughput_class1)/80.0, 5), 5.92823)
 
     def test_baulking(self):
         def my_baulking_function(n):


### PR DESCRIPTION
- If using uniform dist: now doesn't use while loop
- Uses implementation of random.choice from python2
- Does not use random.choice to ensure equality in Ptyhon 2 and 3
- Particular improvements for Empirical distributions