### PR TITLE
Make ciw.create_network more verbose

### DIFF
--- a/ciw/import_params.py
+++ b/ciw/import_params.py
@@ -36,9 +36,6 @@ def create_network(Arrival_distributions=None,
     if Transition_matrices != None:
         params['Transition_matrices'] = Transition_matrices
 
-    for kw in kwargs:
-        params[kw] = kwargs[kw]
-
     return create_network_from_dictionary(params)
 
 
@@ -89,14 +86,14 @@ def create_network_from_dictionary(params_input):
         {'Node ' + str(nd + 1): None for nd in range(number_of_nodes)})
     number_of_servers, schedules, nodes, classes, preempts = [], [], [], [], []
     for c in params['Number_of_servers']:
-        if isinstance(c, str) and c != 'Inf':
-            number_of_servers.append('schedule')
-            if isinstance(params[c], tuple):
-                s = params[c][0]
-                p = params[c][1]
-            else:
-                s = params[c]
+        if isinstance(c, (tuple, list)):
+            if isinstance(c, tuple):
+                s = c[0]
+                p = c[1]
+            if isinstance(c, list):
+                s = c
                 p = False
+            number_of_servers.append('schedule')
             schedules.append(s)
             preempts.append(p)
         elif c == 'Inf':

--- a/ciw/import_params.py
+++ b/ciw/import_params.py
@@ -4,11 +4,42 @@ import copy
 from .network import *
 
 
-def create_network(**kwargs):
+def create_network(Arrival_distributions=None,
+                   Baulking_functions=None,
+                   Class_change_matrices=None,
+                   Number_of_servers=None,
+                   Priority_classes=None,
+                   Queue_capacities=None,
+                   Service_distributions=None,
+                   Transition_matrices=None,
+                   **kwargs):
     """
     Takes in kwargs, creates dictionary.
     """
-    return create_network_from_dictionary(kwargs)
+    if Arrival_distributions == None or Number_of_servers == None or Service_distributions == None:
+        raise ValueError('Arrival_distributions, Service_distributions and Number_of_servers are required arguments.')
+
+    params = {
+        'Arrival_distributions': Arrival_distributions,
+        'Number_of_servers': Number_of_servers,
+        'Service_distributions': Service_distributions
+    }
+
+    if Baulking_functions != None:
+        params['Baulking_functions'] = Baulking_functions
+    if Class_change_matrices != None:
+        params['Class_change_matrices'] = Class_change_matrices
+    if Priority_classes != None:
+        params['Priority_classes'] = Priority_classes
+    if Queue_capacities != None:
+        params['Queue_capacities'] = Queue_capacities
+    if Transition_matrices != None:
+        params['Transition_matrices'] = Transition_matrices
+
+    for kw in kwargs:
+        params[kw] = kwargs[kw]
+
+    return create_network_from_dictionary(params)
 
 
 def load_parameters(directory_name):

--- a/ciw/import_params.py
+++ b/ciw/import_params.py
@@ -11,8 +11,7 @@ def create_network(Arrival_distributions=None,
                    Priority_classes=None,
                    Queue_capacities=None,
                    Service_distributions=None,
-                   Transition_matrices=None,
-                   **kwargs):
+                   Transition_matrices=None):
     """
     Takes in kwargs, creates dictionary.
     """

--- a/ciw/tests/test_network.py
+++ b/ciw/tests/test_network.py
@@ -541,3 +541,13 @@ class TestCreateNetworkKwargs(unittest.TestCase):
                                                                    [0.0, 0.0, 0.0]])
         self.assertEqual(N.customer_classes[0].baulking_functions, [None, None, example_baulking_function])
         self.assertEqual(N.number_of_priority_classes, 1)
+
+
+    def test_error_no_arrivals_servers_services(self):
+        self.assertRaises(ValueError, ciw.create_network, {})
+        self.assertRaises(ValueError, ciw.create_network, {'Arrival_distributions': [['Exponential', 0.2]]})
+        self.assertRaises(ValueError, ciw.create_network, {'Service_distributions': [['Exponential', 0.2]]})
+        self.assertRaises(ValueError, ciw.create_network, {'Number_of_servers': [1]})
+        self.assertRaises(ValueError, ciw.create_network, {'Arrival_distributions': [['Exponential', 0.2]], 'Number_of_servers': [1]})
+        self.assertRaises(ValueError, ciw.create_network, {'Arrival_distributions': [['Exponential', 0.2]], 'Service_distributions': [['Exponential', 0.2]]})
+        self.assertRaises(ValueError, ciw.create_network, {'Service_distributions': [['Exponential', 0.2]], 'Number_of_servers': [1]})

--- a/ciw/tests/test_network.py
+++ b/ciw/tests/test_network.py
@@ -115,9 +115,7 @@ class TestNetwork(unittest.TestCase):
         params = {'Arrival_distributions': {'Class 0': [['Exponential', 3.0]]},
                   'Service_distributions': {'Class 0': [['Exponential', 7.0]]},
                   'Number_of_servers': [9],
-                  'Number_of_classes': 1,
                   'Transition_matrices': {'Class 0': [[0.5]]},
-                  'Number_of_nodes': 1,
                   'Queue_capacities': ['Inf']}
         N = ciw.create_network_from_dictionary(params)
         
@@ -139,12 +137,11 @@ class TestNetwork(unittest.TestCase):
                                             ['Uniform', 0.2, 0.6]],
                   'Service_distributions': [['Exponential', 7.0],
                                             ['Deterministic', 0.7]],
-                  'Number_of_servers': ['my_amazing_schedule', 3],
+                  'Number_of_servers': [[[1, 20], [4, 50]], 3],
                   'Transition_matrices': [[0.5, 0.2],
                                           [0.0, 0.0]],
-                  'Queue_capacities': [10, 'Inf'],
-                  'my_amazing_schedule': [[1, 20],
-                                          [4, 50]]}
+                  'Queue_capacities': [10, 'Inf']
+                  }
         N = ciw.create_network_from_dictionary(params)
         self.assertEqual(N.number_of_nodes, 2)
         self.assertEqual(N.number_of_classes, 1)
@@ -172,7 +169,6 @@ class TestNetwork(unittest.TestCase):
                   'Number_of_servers': [9],
                   'Transition_matrices': {'Class 0': [[0.5]],
                                           'Class 1': [[0.0]]},
-                  'Number_of_nodes': 1,
                   'Queue_capacities': ['Inf'],
                   'Class_change_matrices': {'Node 1': [[0.0, 1.0],
                                                        [0.2, 0.8]]}}
@@ -201,7 +197,6 @@ class TestNetwork(unittest.TestCase):
                   'Number_of_servers': [9],
                   'Transition_matrices': {'Class 0': [[0.5]],
                                           'Class 1': [[0.0]]},
-                  'Number_of_nodes': 1,
                   'Queue_capacities': ['Inf'],
                   'Priority_classes': {'Class 0': 1,
                                        'Class 1': 0}}
@@ -230,7 +225,6 @@ class TestNetwork(unittest.TestCase):
                   'Transition_matrices': [[0.5, 0.0, 0.1],
                                           [0.2, 0.1, 0.0],
                                           [0.0, 0.0, 0.0]],
-                  'Number_of_nodes': 3,
                   'Queue_capacities': ['Inf', 'Inf', 'Inf'],
                   'Baulking_functions': [None, None, example_baulking_function]}
         N = ciw.create_network_from_dictionary(params)
@@ -413,12 +407,10 @@ class TestCreateNetworkKwargs(unittest.TestCase):
                                        ['Uniform', 0.2, 0.6]],
                 Service_distributions=[['Exponential', 7.0],
                                        ['Deterministic', 0.7]],
-                Number_of_servers=['my_amazing_schedule', 3],
+                Number_of_servers=[[[1, 20], [4, 50]], 3],
                 Transition_matrices=[[0.5, 0.2],
                                      [0.0, 0.0]],
-                Queue_capacities=[10, 'Inf'],
-                my_amazing_schedule=[[1, 20],
-                                     [4, 50]]
+                Queue_capacities=[10, 'Inf']
             )
 
         self.assertEqual(N.number_of_nodes, 2)
@@ -551,3 +543,11 @@ class TestCreateNetworkKwargs(unittest.TestCase):
         self.assertRaises(ValueError, ciw.create_network, {'Arrival_distributions': [['Exponential', 0.2]], 'Number_of_servers': [1]})
         self.assertRaises(ValueError, ciw.create_network, {'Arrival_distributions': [['Exponential', 0.2]], 'Service_distributions': [['Exponential', 0.2]]})
         self.assertRaises(ValueError, ciw.create_network, {'Service_distributions': [['Exponential', 0.2]], 'Number_of_servers': [1]})
+
+    def test_error_extra_args(self):
+        params = {'Arrival_distributions': [['Exponential', 3.0]],
+                  'Service_distributions': [['Exponential', 7.0]],
+                  'Number_of_servers': [4],
+                  'Something_else': 56
+                  }
+        self.assertRaises(ValueError, ciw.create_network, params)

--- a/ciw/tests/test_network.py
+++ b/ciw/tests/test_network.py
@@ -382,9 +382,7 @@ class TestCreateNetworkKwargs(unittest.TestCase):
                 Arrival_distributions={'Class 0': [['Exponential', 3.0]]},
                 Service_distributions={'Class 0': [['Exponential', 7.0]]},
                 Number_of_servers=[9],
-                Number_of_classes=1,
                 Transition_matrices={'Class 0': [[0.5]]},
-                Number_of_nodes=1,
                 Queue_capacities=['Inf']
             )
         
@@ -440,7 +438,6 @@ class TestCreateNetworkKwargs(unittest.TestCase):
                 Number_of_servers=[9],
                 Transition_matrices={'Class 0': [[0.5]],
                                      'Class 1': [[0.0]]},
-                Number_of_nodes=1,
                 Queue_capacities=['Inf'],
                 Class_change_matrices={'Node 1': [[0.0, 1.0],
                                                   [0.2, 0.8]]}
@@ -471,7 +468,6 @@ class TestCreateNetworkKwargs(unittest.TestCase):
                 Number_of_servers=[9],
                 Transition_matrices={'Class 0': [[0.5]],
                                      'Class 1': [[0.0]]},
-                Number_of_nodes=1,
                 Queue_capacities=['Inf'],
                 Priority_classes={'Class 0': 1,
                                   'Class 1': 0}
@@ -506,7 +502,6 @@ class TestCreateNetworkKwargs(unittest.TestCase):
                 Transition_matrices=[[0.5, 0.0, 0.1],
                                      [0.2, 0.1, 0.0],
                                      [0.0, 0.0, 0.0]],
-                Number_of_nodes=3,
                 Queue_capacities=['Inf', 'Inf', 'Inf'],
                 Baulking_functions=[None, None, example_baulking_function]
             )
@@ -536,13 +531,20 @@ class TestCreateNetworkKwargs(unittest.TestCase):
 
 
     def test_error_no_arrivals_servers_services(self):
-        self.assertRaises(ValueError, ciw.create_network, {})
-        self.assertRaises(ValueError, ciw.create_network, {'Arrival_distributions': [['Exponential', 0.2]]})
-        self.assertRaises(ValueError, ciw.create_network, {'Service_distributions': [['Exponential', 0.2]]})
-        self.assertRaises(ValueError, ciw.create_network, {'Number_of_servers': [1]})
-        self.assertRaises(ValueError, ciw.create_network, {'Arrival_distributions': [['Exponential', 0.2]], 'Number_of_servers': [1]})
-        self.assertRaises(ValueError, ciw.create_network, {'Arrival_distributions': [['Exponential', 0.2]], 'Service_distributions': [['Exponential', 0.2]]})
-        self.assertRaises(ValueError, ciw.create_network, {'Service_distributions': [['Exponential', 0.2]], 'Number_of_servers': [1]})
+        with self.assertRaises(ValueError):
+            ciw.create_network()
+        with self.assertRaises(ValueError):
+            ciw.create_network(Arrival_distributions=[['Exponential', 0.2]])
+        with self.assertRaises(ValueError):
+            ciw.create_network(Service_distributions=[['Exponential', 0.2]])
+        with self.assertRaises(ValueError):
+            ciw.create_network(Number_of_servers=[1])
+        with self.assertRaises(ValueError):
+            ciw.create_network(Arrival_distributions=[['Exponential', 0.2]], Number_of_servers=[1])
+        with self.assertRaises(ValueError):
+            ciw.create_network(Arrival_distributions=[['Exponential', 0.2]], Service_distributions=[['Exponential', 0.2]])
+        with self.assertRaises(ValueError):
+            ciw.create_network(Service_distributions=[['Exponential', 0.2]], Number_of_servers=[1])
 
     def test_error_extra_args(self):
         params = {'Arrival_distributions': [['Exponential', 3.0]],
@@ -550,4 +552,5 @@ class TestCreateNetworkKwargs(unittest.TestCase):
                   'Number_of_servers': [4],
                   'Something_else': 56
                   }
-        self.assertRaises(ValueError, ciw.create_network, params)
+        with self.assertRaises(TypeError):
+            ciw.create_network(**params)

--- a/ciw/tests/test_scheduling.py
+++ b/ciw/tests/test_scheduling.py
@@ -188,8 +188,7 @@ class TestScheduling(unittest.TestCase):
             'Arrival_distributions': [['Deterministic', 7.0]],
             'Service_distributions': [['Deterministic', 5.0]],
             'Transition_matrices': [[0.0]],
-            'ourschedule': ([[1, 15], [0, 17], [2, 100]], True),
-            'Number_of_servers': ['ourschedule']
+            'Number_of_servers': [([[1, 15], [0, 17], [2, 100]], True)]
         }
         N = ciw.create_network(**params)
         Q = ciw.Simulation(N)
@@ -213,8 +212,7 @@ class TestScheduling(unittest.TestCase):
             'Arrival_distributions': [['Deterministic', 7.0]],
             'Service_distributions': [['Deterministic', 5.0]],
             'Transition_matrices': [[0.0]],
-            'ourschedule': ([[1, 15], [0, 17], [2, 100]], True),
-            'Number_of_servers': ['ourschedule']
+            'Number_of_servers': [([[1, 15], [0, 17], [2, 100]], True)]
         }
         N = ciw.create_network(**params)
         Q = ciw.Simulation(N)
@@ -238,8 +236,7 @@ class TestScheduling(unittest.TestCase):
             'Arrival_distributions': [['Deterministic', 3.0]],
             'Service_distributions': [['Deterministic', 10.0]],
             'Transition_matrices': [[0.0]],
-            'ourschedule': ([[4, 12.5], [0, 17], [1, 100]], True),
-            'Number_of_servers': ['ourschedule']
+            'Number_of_servers': [([[4, 12.5], [0, 17], [1, 100]], True)]
         }
         N = ciw.create_network(**params)
         Q = ciw.Simulation(N)

--- a/ciw/tests/test_simulation.py
+++ b/ciw/tests/test_simulation.py
@@ -386,9 +386,8 @@ class TestSimulation(unittest.TestCase):
         params = {'Arrival_distributions': [['Exponential', 20]],
                   'Service_distributions': [['Deterministic', 0.01]],
                   'Transition_matrices': [[0.0]],
-                  'Number_of_servers': ['server_schedule'],
-                  'server_schedule': [[0, 0.5], [1, 0.55], [0, 3.0]]}
-
+                  'Number_of_servers': [[[0, 0.5], [1, 0.55], [0, 3.0]]]
+                  }
         ciw.seed(777)
         Q = ciw.Simulation(ciw.create_network(**params))
         Q.simulate_until_max_time(10)
@@ -416,8 +415,8 @@ class TestSimulation(unittest.TestCase):
         params = {'Arrival_distributions': [['Exponential', 20]],
                   'Service_distributions': [['Deterministic', 0.01]],
                   'Transition_matrices': [[0.0]],
-                  'Number_of_servers': ['server_schedule'],
-                  'server_schedule': [[0, 0.5], [1, 0.55], [0, 3.0]]}
+                  'Number_of_servers': [[[0, 0.5], [1, 0.55], [0, 3.0]]]
+                  }
         Q = ciw.Simulation(ciw.create_network(**params))
         self.assertEqual(Q.NodeType, ciw.Node)
         self.assertEqual(Q.ArrivalNodeType, ciw.ArrivalNode)
@@ -448,9 +447,8 @@ class TestSimulation(unittest.TestCase):
         params = {'Arrival_distributions': [['Exponential', 20]],
                   'Service_distributions': [['Deterministic', 0.01]],
                   'Transition_matrices': [[0.0]],
-                  'Number_of_servers': ['server_schedule'],
-                  'server_schedule': [[0, 0.5], [1, 0.55], [0, 3.0]]}
-
+                  'Number_of_servers': [[[0, 0.5], [1, 0.55], [0, 3.0]]]
+                  }
         Q = ciw.Simulation(ciw.create_network(**params),
             node_class=None, arrival_node_class=None)
         self.assertEqual(Q.NodeType, ciw.Node)

--- a/ciw/tests/testing_parameters/params.yml
+++ b/ciw/tests/testing_parameters/params.yml
@@ -26,8 +26,6 @@ Arrival_distributions:
     - 2.0
   - - Exponential
     - 0.5
-Number_of_classes: 3
-Number_of_nodes: 4
 Number_of_servers:
 - 9
 - 10
@@ -69,7 +67,6 @@ Service_distributions:
     - 8.0
   - - Exponential
     - 9.0
-Simulation_time: 150
 Transition_matrices:
   Class 0:
   - - 0.1

--- a/ciw/tests/testing_parameters/params_priorities.yml
+++ b/ciw/tests/testing_parameters/params_priorities.yml
@@ -9,8 +9,6 @@ Arrival_distributions:
     - 0.04
   - - Exponential
     - 0.06
-Number_of_classes: 2
-Number_of_nodes: 2
 Number_of_servers:
 - 4
 - 3
@@ -28,7 +26,6 @@ Service_distributions:
     - 10.0
   - - Deterministic
     - 10.0
-Simulation_time: 50
 Transition_matrices:
   Class 0:
   - - 0.8

--- a/ciw/tests/testing_parameters/params_schedule.yml
+++ b/ciw/tests/testing_parameters/params_schedule.yml
@@ -12,7 +12,7 @@ Arrival_distributions:
 Number_of_classes: 2
 Number_of_nodes: 2
 Number_of_servers:
-- 'schedule_1'
+- [[1, 30], [2, 60], [1, 90], [3, 100]]
 - 3
 Queue_capacities:
 - "Inf"
@@ -40,12 +40,3 @@ Transition_matrices:
     - 0.1
   - - 0.2
     - 0.0
-schedule_1:
-  - - 1
-    - 30
-  - - 2
-    - 60
-  - - 1
-    - 90
-  - - 3
-    - 100

--- a/docs/Guides/server_schedule.rst
+++ b/docs/Guides/server_schedule.rst
@@ -22,15 +22,13 @@ This is defines by a list of lists indicating the number of servers that should 
 Here we are saying that there will be 2 servers scheduled between times 0 and 10, 0 between 10 and 30, etc.
 This fully defines the cyclic work schedule.
 
-To tell Ciw to use this schedule for a given node, in the :code:`Number_of_servers` keyword we replace an integer with the schedule name.
-Also to include as a keyword is the schedule itself::
+To tell Ciw to use this schedule for a given node, in the :code:`Number_of_servers` keyword we replace an integer with the schedule::
 
     >>> import ciw
     >>> N = ciw.create_network(
     ...     Arrival_distributions=[['Exponential', 5]],
     ...     Service_distributions=[['Exponential', 10]],
-    ...     Number_of_servers=['schedule'],
-    ...     schedule=[[2, 10], [0, 30], [1, 100]]
+    ...     Number_of_servers=[[[2, 10], [0, 30], [1, 100]]]
     ... )
 
 Simulating this system, we'll see that no services begin between dates 10 and 30, nor between dates 110 and 130::
@@ -60,13 +58,13 @@ When a server is due to go off duty during a customer's service, there are two o
 
 In order to implement pre-emptive or non-pre-emptive schedules, put the schedule in a tuple with a :code:`True` or a :code:`False` as the second term, indicating pre-emptive or non-pre-emptive interruptions. For example::
 
-    preemptive_schedule=([[2, 10], [0, 30], [1, 100]], True)
+    Number_of_servers=[([[2, 10], [0, 30], [1, 100]], True)] # preemptive
 
 And::
 
-    nonpreemptive_schedule=([[2, 10], [0, 30], [1, 100]], False)
+    Number_of_servers=[([[2, 10], [0, 30], [1, 100]], False)] # non-preemptive
 
 Ciw defaults to non-pre-emptive schedules, and so the following code implies a non-pre-emptive schedule::
 
-    schedule=[[2, 10], [0, 30], [1, 100]]
+    Number_of_servers=[[[2, 10], [0, 30], [1, 100]]] # non-preemptive
 


### PR DESCRIPTION
+ Remove kwargs
+ refactor schedules so that they are defined within the Number_of_servers list