### PR TITLE
Attempt to implement context manager (do not merge)

### DIFF
--- a/ciw/simulation.py
+++ b/ciw/simulation.py
@@ -43,7 +43,7 @@ class Simulation(object):
         self.batch_sizes = self.find_batches_dict()
         self.number_of_priority_classes = self.network.number_of_priority_classes
         self.transitive_nodes = [self.NodeType(i + 1, self)
-            for i in range(network.number_of_nodes)]
+                                 for i in range(network.number_of_nodes)]
         self.nodes = ([self.ArrivalNodeType(self)] +
                       self.transitive_nodes +
                       [ExitNode()])
@@ -397,3 +397,20 @@ class Simulation(object):
         for row in records:
             csv_wrtr.writerow(row)
         data_file.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        for node in self.nodes[1: -1]:
+            for server in node.individuals:
+                for individual in server:
+                    del individual.data_records[:]
+                    del individual
+                del server[:]
+            del node.individuals[:]
+
+        for individual in self.nodes[-1].all_individuals:
+            del individual.data_records[:]
+            del individual
+        del self.nodes[-1].all_individuals[:]

--- a/ciw/tests/test_simulation.py
+++ b/ciw/tests/test_simulation.py
@@ -768,3 +768,33 @@ class TestSimulation(unittest.TestCase):
         self.assertTrue(isinstance(Q_all.generators['Ser'][0][1], cycle))
         self.assertTrue(isinstance(Q_all.generators['Ser'][1][0], cycle))
         self.assertTrue(isinstance(Q_all.generators['Ser'][1][1], cycle))
+
+    def test_enter_and_exit(self):
+        """
+        Test the context manager:
+
+        - Records are deleted;
+        - Individuals are deleted
+        """
+        N1 = ciw.create_network_from_yml(
+          'ciw/tests/testing_parameters/params.yml')
+        with ciw.Simulation(N1) as Q:
+            Q.simulate_until_max_time(50)
+            records = Q.nodes[-1].all_individuals[0].data_records
+            individuals = Q.nodes[-1].all_individuals
+            individual = individuals[0]
+
+            self.assertIsInstance(records, list)
+            self.assertGreater(len(records), 0)
+
+            self.assertIsInstance(individuals, list)
+            self.assertGreater(len(individuals), 0)
+
+            self.assertIsInstance(individual, ciw.Individual)
+
+        self.assertEqual(len(records), 0)
+        self.assertEqual(len(individuals), 0)
+
+        # This test fails: I seem unable to delete the individuals
+        with self.assertRaises(NameError):
+            individual


### PR DESCRIPTION
This isn't working: see failing test.

Essentially I can't figure out how to delete an item using the pointer
in the list:

```python
>>> stuff = [1, 2, 3, 4]
>>> vince = stuff[2]
>>> del stuff[:]
>>> stuff, vince
([], 3)

```

I've read quite a few things that essentially say: "if you're trying to
do this, try to do something else". For example
https://stackoverflow.com/questions/1316767/how-can-i-explicitly-free-memory-in-python
(although the advice of using generators doesn't apply here).

I believe this is inherent to how ciw is built and that there's
potentially quite a few cyclic connections.

If we can't figure out how to delete an element inside a list I'd
suggest going down the line of not having classes for customers at all
(named tuples as you suggested Geraint) and writing out to file.

I think moving to named tuples shouldn't be too hard (it's essentially
what the classes are for here) and then subsequently writing out to file
would be a bit of work.