### PR TITLE
Refactor current time

### DIFF
--- a/ciw/arrival_node.py
+++ b/ciw/arrival_node.py
@@ -85,12 +85,10 @@ class ArrivalNode(object):
             self.next_class] = self.increment_time(
             self.event_dates_dict[self.next_node][
             self.next_class], self.inter_arrival(
-            self.next_node, self.next_class,
-            self.next_event_date))
+            self.next_node, self.next_class))
         self.batch_size_dict[self.next_node][
             self.next_class] = self.batch_size(
-            self.next_node, self.next_class,
-            self.next_event_date)
+            self.next_node, self.next_class)
         self.find_next_event_date()
 
     def increment_time(self, original, increment):
@@ -107,7 +105,7 @@ class ArrivalNode(object):
         for nd in self.event_dates_dict:
             for clss in self.event_dates_dict[nd]:
                 self.event_dates_dict[nd][
-                clss] = self.inter_arrival(nd, clss, 0.0)
+                clss] = self.inter_arrival(nd, clss)
 
     def initialise_batch_size_dict(self):
         """
@@ -117,18 +115,18 @@ class ArrivalNode(object):
         for nd in self.batch_size_dict:
             for clss in self.batch_size_dict[nd]:
                 self.batch_size_dict[nd][
-                clss] = self.batch_size(nd, clss, 0.0)
+                clss] = self.batch_size(nd, clss)
 
-    def inter_arrival(self, nd, clss, current_time):
+    def inter_arrival(self, nd, clss):
         """
         Samples the inter-arrival time for next class and node.
         """
         if self.simulation.network.customer_classes[
             clss].arrival_distributions[nd-1][0] == "TimeDependent":
-            return self.simulation.inter_arrival_times[nd][clss](current_time)
+            return self.simulation.inter_arrival_times[nd][clss](self.simulation.current_time)
         return self.simulation.inter_arrival_times[nd][clss]()
 
-    def batch_size(self, nd, clss, current_time):
+    def batch_size(self, nd, clss):
         """
         Samples the batch size for next class and node.
         """
@@ -168,7 +166,7 @@ class ArrivalNode(object):
         Sends the next_individual to the next_node
         """
         self.number_accepted_individuals += 1
-        next_node.accept(next_individual, self.next_event_date)
+        next_node.accept(next_individual)
 
     def update_next_event_date(self):
         """

--- a/ciw/exactnode.py
+++ b/ciw/exactnode.py
@@ -21,20 +21,20 @@ class ExactNode(Node):
         """
         return Decimal(str(original)) + Decimal(str(increment))
 
-    def get_service_time(self, clss, current_time):
+    def get_service_time(self, clss):
         """
         Returns a service time for the given customer class
         """
         if self.simulation.network.customer_classes[clss].service_distributions[self.id_number-1][0] == "TimeDependent":
-            return Decimal(str(self.simulation.service_times[self.id_number][clss](current_time)))
+            return Decimal(str(self.simulation.service_times[self.id_number][clss](self.get_now())))
         return Decimal(str(self.simulation.service_times[self.id_number][clss]()))
 
 
-    def get_now(self, current_time):
+    def get_now(self):
         """
         Gets the current time
         """
-        return Decimal(str(current_time))
+        return Decimal(self.simulation.current_time)
 
 
 class ExactArrivalNode(ArrivalNode):
@@ -49,11 +49,11 @@ class ExactArrivalNode(ArrivalNode):
         """
         return Decimal(str(original)) + Decimal(str(increment))
 
-    def inter_arrival(self, nd, clss, current_time):
+    def inter_arrival(self, nd, clss):
         """
         Samples the inter-arrival time for next class and node.
         """
         if self.simulation.network.customer_classes[clss].arrival_distributions[nd-1][0] == "TimeDependent":
-            return Decimal(str(self.simulation.inter_arrival_times[nd][clss](current_time)))
+            return Decimal(str(self.simulation.inter_arrival_times[nd][clss](self.simulation.current_time)))
         return Decimal(str(self.simulation.inter_arrival_times[nd][clss]()))
 

--- a/ciw/exactnode.py
+++ b/ciw/exactnode.py
@@ -26,7 +26,7 @@ class ExactNode(Node):
         Returns a service time for the given customer class
         """
         if self.simulation.network.customer_classes[clss].service_distributions[self.id_number-1][0] == "TimeDependent":
-            return Decimal(str(self.simulation.service_times[self.id_number][clss](self.get_now())))
+            return Decimal(str(self.simulation.service_times[self.id_number][clss](self.simulation.current_time)))
         return Decimal(str(self.simulation.service_times[self.id_number][clss]()))
 
 

--- a/ciw/exit_node.py
+++ b/ciw/exit_node.py
@@ -20,7 +20,7 @@ class ExitNode(object):
         """
         return 'Exit Node'
 
-    def accept(self, next_individual, current_time):
+    def accept(self, next_individual):
         """
         Adds customer to the list of completed customers
         """

--- a/ciw/node.py
+++ b/ciw/node.py
@@ -404,7 +404,7 @@ class Node(object):
         """
         if self.simulation.network.customer_classes[clss].service_distributions[
             self.id_number-1][0] == 'TimeDependent':
-            return self.simulation.service_times[self.id_number][clss](self.get_now())
+            return self.simulation.service_times[self.id_number][clss](self.simulation.current_time)
         return self.simulation.service_times[self.id_number][clss]()
 
     def take_servers_off_duty(self):

--- a/ciw/tests/test_arrival_node.py
+++ b/ciw/tests/test_arrival_node.py
@@ -142,7 +142,7 @@ class TestArrivalNode(unittest.TestCase):
         self.assertEqual(
             AN.simulation.network.customer_classes[0].arrival_distributions[0],
             'NoArrivals')
-        self.assertEqual(AN.inter_arrival(1, 0, 0.0), float('Inf'))
+        self.assertEqual(AN.inter_arrival(1, 0), float('Inf'))
 
     def test_rejection_dict(self):
         params = {'Arrival_distributions':[['Deterministic', 3.0],

--- a/ciw/tests/test_exit_node.py
+++ b/ciw/tests/test_exit_node.py
@@ -28,9 +28,9 @@ class TestExitNode(unittest.TestCase):
         i1 = ciw.Individual(3)
         i2 = ciw.Individual(8)
         self.assertEqual(n.all_individuals, [])
-        n.accept(i1, 42.1)
+        n.accept(i1)
         self.assertEqual(n.all_individuals, [i1])
-        n.accept(i2, 51.8)
+        n.accept(i2)
         self.assertEqual(n.all_individuals, [i1, i2])
 
     def test_update_next_event_date_method(self):

--- a/ciw/tests/test_sampling.py
+++ b/ciw/tests/test_sampling.py
@@ -744,13 +744,15 @@ class TestSampling(unittest.TestCase):
 
         samples = []
         for t in [3.0, 9.0, 9.0, 11.0, 11.0]:
-            samples.append(round(N1.get_service_time(0, t), 2))
+            Q.current_time = t
+            samples.append(round(N1.get_service_time(0), 2))
         expected = [3.0, 3.0, 3.0, 5.0, 5.0]
         self.assertEqual(samples, expected)
 
         samples = []
         for t in [4.0, 4.0, 17.0, 22.0, 22.0]:
-            samples.append(round(N2.get_service_time(0, t), 2))
+            Q.current_time = t
+            samples.append(round(N2.get_service_time(0), 2))
         expected = [2.0, 2.0, 8.5, 8.0, 8.0]
         self.assertEqual(samples, expected)
 

--- a/ciw/tests/test_sampling.py
+++ b/ciw/tests/test_sampling.py
@@ -688,13 +688,15 @@ class TestSampling(unittest.TestCase):
 
         samples = []
         for t in [3.0, 9.0, 9.0, 11.0, 11.0]:
-            samples.append(round(N1.get_service_time(0, t), 2))
+            Q.current_time = t
+            samples.append(round(N1.get_service_time(0), 2))
         expected = [3.0, 3.0, 3.0, 5.0, 5.0]
         self.assertEqual(samples, expected)
 
         samples = []
         for t in [4.0, 4.0, 17.0, 22.0, 22.0]:
-            samples.append(round(N2.get_service_time(0, t), 2))
+            Q.current_time = t
+            samples.append(round(N2.get_service_time(0), 2))
         expected = [2.0, 2.0, 8.5, 8.0, 8.0]
         self.assertEqual(samples, expected)
 
@@ -722,8 +724,9 @@ class TestSampling(unittest.TestCase):
         Q = ciw.Simulation(ciw.create_network(**params))
         N = Q.transitive_nodes[0]
         ciw.seed(5)
+        Q.current_time = 3.0
         self.assertRaises(ValueError, N.simulation.service_times[N.id_number][0], 3.0)
-        self.assertRaises(ValueError, N.get_service_time, 0, 3.0)
+        self.assertRaises(ValueError, N.get_service_time, 0)
 
     def test_timedependent_exact(self):
         params = {

--- a/ciw/tests/test_state_tracker.py
+++ b/ciw/tests/test_state_tracker.py
@@ -51,12 +51,14 @@ class TestStateTracker(unittest.TestCase):
             srvr = N.find_free_server()
             N.attach_server(srvr, ind)
         self.assertEqual(Q.statetracker.state, None)
-        N.release(0, Q.nodes[1], 43.11)
+        Q.current_time = 43.11
+        N.release(0, Q.nodes[1])
         self.assertEqual(Q.statetracker.state, None)
         N.all_individuals[1].is_blocked = True
-        N.release(1, Q.nodes[1], 46.72)
+        Q.current_time = 46.72
+        N.release(1, Q.nodes[1])
         self.assertEqual(Q.statetracker.state, None)
-        N.release(1, Q.nodes[-1], 46.72)
+        N.release(1, Q.nodes[-1])
         self.assertEqual(Q.statetracker.state, None)
 
     def test_base_block_method_within_simulation(self):
@@ -74,7 +76,8 @@ class TestStateTracker(unittest.TestCase):
         Q = ciw.Simulation(Net)
         N = Q.transitive_nodes[2]
         self.assertEqual(Q.statetracker.state, None)
-        N.accept(ciw.Individual(3, 2), 45.6)
+        Q.current_time = 45.6
+        N.accept(ciw.Individual(3, 2))
         self.assertEqual(Q.statetracker.state, None)
 
 
@@ -134,12 +137,14 @@ class TestNaiveTracker(unittest.TestCase):
             N.attach_server(srvr, ind)
         Q.statetracker.state = [[4, 1], [3, 0], [5, 1], [0, 0]]
         self.assertEqual(Q.statetracker.state, [[4, 1], [3, 0], [5, 1], [0, 0]])
-        N.release(0, Q.nodes[1], 43.11)
+        Q.current_time = 43.11
+        N.release(0, Q.nodes[1])
         self.assertEqual(Q.statetracker.state, [[5, 1], [3, 0], [4, 1], [0, 0]])
         N.all_individuals[1].is_blocked = True
-        N.release(1, Q.nodes[1], 46.72)
+        Q.current_time = 46.72
+        N.release(1, Q.nodes[1])
         self.assertEqual(Q.statetracker.state, [[6, 1], [3, 0], [4, 0], [0, 0]])
-        N.release(1, Q.nodes[-1], 46.72)
+        N.release(1, Q.nodes[-1])
         self.assertEqual(Q.statetracker.state, [[6, 1], [3, 0], [3, 0], [0, 0]])
 
     def test_naive_block_method_within_simulation(self):
@@ -158,7 +163,8 @@ class TestNaiveTracker(unittest.TestCase):
         Q = ciw.Simulation(params, tracker='Naive')
         N = Q.transitive_nodes[2]
         self.assertEqual(Q.statetracker.state, [[0, 0], [0, 0], [0, 0], [0, 0]])
-        N.accept(ciw.Individual(3, 2), 45.6)
+        Q.current_time = 45.6
+        N.accept(ciw.Individual(3, 2))
         self.assertEqual(Q.statetracker.state, [[0, 0], [0, 0], [1, 0], [0, 0]])
 
 
@@ -279,20 +285,23 @@ class TestMatrixTracker(unittest.TestCase):
                                                  [[1], [],  [], []],
                                                  [[],  [],  [], []]],
                                                  [5, 3, 6, 0]])
-        N.release(0, Q.nodes[1], 43.11)
+        Q.current_time = 43.11
+        N.release(0, Q.nodes[1])
         self.assertEqual(Q.statetracker.state, [[[[],  [2], [], []],
                                                  [[],  [],  [], []],
                                                  [[1], [],  [], []],
                                                  [[],  [],  [], []]],
                                                  [6, 3, 5, 0]])
         N.all_individuals[1].is_blocked = True
-        N.release(1, Q.nodes[1], 46.72)
+        Q.current_time = 46.72
+        N.release(1, Q.nodes[1])
         self.assertEqual(Q.statetracker.state, [[[[], [1], [], []],
                                                  [[], [],  [], []],
                                                  [[], [],  [], []],
                                                  [[], [],  [], []]],
                                                  [7, 3, 4, 0]])
-        N.release(1, Q.nodes[-1], 48.39)
+        Q.current_time = 48.39
+        N.release(1, Q.nodes[-1])
         self.assertEqual(Q.statetracker.state, [[[[], [1], [], []],
                                                  [[], [],  [], []],
                                                  [[], [],  [], []],
@@ -332,7 +341,8 @@ class TestMatrixTracker(unittest.TestCase):
                                                  [[], [], [], []],
                                                  [[], [], [], []]],
                                                  [0, 0, 0, 0]])
-        N.accept(ciw.Individual(3, 2), 45.6)
+        Q.current_time = 45.6
+        N.accept(ciw.Individual(3, 2))
         self.assertEqual(Q.statetracker.state, [[[[], [], [], []],
                                                  [[], [], [], []],
                                                  [[], [], [], []],

--- a/docs/Guides/behaviour.rst
+++ b/docs/Guides/behaviour.rst
@@ -46,9 +46,9 @@ First create the :code:`CustomArrivalNode` that inherits from :code:`ciw.Arrival
 	...         """
 	...         self.number_accepted_individuals += 1
 	...         if len(next_node.all_individuals) <= 10:
-	...             next_node.accept(next_individual, self.next_event_date)
+	...             next_node.accept(next_individual)
 	...         else:
-	...             self.simulation.nodes[2].accept(next_individual, self.next_event_date)
+	...             self.simulation.nodes[2].accept(next_individual)
 
 To run the same system, we need to remove the keyword :code:`'Queue_capacities'` when creating a network, so that customers are not rejected before reaching the :code:`send_individual` method::
 


### PR DESCRIPTION
`current_time` is now an attribute of the `Simulation` object, accessible as a single attribute from everywhere.