### PR TITLE
HDW refactor of `distribution-objects`

### DIFF
--- a/ciw/dists/distributions.py
+++ b/ciw/dists/distributions.py
@@ -1,6 +1,7 @@
 from ciw.auxiliary import *
 from itertools import cycle
 import copy
+from operator import add, mul, sub, truediv
 from random import (expovariate, uniform, triangular, gammavariate,
                     lognormvariate, weibullvariate)
 
@@ -26,67 +27,47 @@ class Distribution(object):
 
     def __add__(self, dist):
         """
-        Add two distirbutions such that sampling is the sum of the samples.
+        Add two distributions such that sampling is the sum of the samples.
         """
-        class CombinedDistribution(Distribution):
-            def __init__(newself, self, dist):
-                newself.d1 = copy.deepcopy(self)
-                newself.d2 = copy.deepcopy(dist)
-            def __repr__(newself):
-                return 'CombinedDistribution'
-            def sample(newself, t=None):
-                s1 = newself.d1.sample()
-                s2 = newself.d2.sample()
-                return s1 + s2
-        return CombinedDistribution(self, dist)
+        return CombinedDistribution(self, dist, add)
 
     def __sub__(self, dist):
         """
-        Subtract two distirbutions such that sampling is the sum of the samples.
+        Subtract two distributions such that sampling is the difference of the samples.
         """
-        class CombinedDistribution(Distribution):
-            def __init__(newself, self, dist):
-                newself.d1 = copy.deepcopy(self)
-                newself.d2 = copy.deepcopy(dist)
-            def __repr__(newself):
-                return 'CombinedDistribution'
-            def sample(newself, t=None):
-                s1 = newself.d1.sample()
-                s2 = newself.d2.sample()
-                return s1 - s2
-        return CombinedDistribution(self, dist)
+        return CombinedDistribution(self, dist, sub)
 
     def __mul__(self, dist):
         """
-        Add two distirbutions such that sampling is the sum of the samples.
+        Multiply two distributions such that sampling is the product of the samples.
         """
-        class CombinedDistribution(Distribution):
-            def __init__(newself, self, dist):
-                newself.d1 = copy.deepcopy(self)
-                newself.d2 = copy.deepcopy(dist)
-            def __repr__(newself):
-                return 'CombinedDistribution'
-            def sample(newself, t=None):
-                s1 = newself.d1.sample()
-                s2 = newself.d2.sample()
-                return s1 * s2
-        return CombinedDistribution(self, dist)
+        return CombinedDistribution(self, dist, mul)
 
     def __truediv__(self, dist):
         """
-        Add two distirbutions such that sampling is the sum of the samples.
+        Divide two distributions such that sampling is the ratio of the samples.
         """
-        class CombinedDistribution(Distribution):
-            def __init__(newself, self, dist):
-                newself.d1 = copy.deepcopy(self)
-                newself.d2 = copy.deepcopy(dist)
-            def __repr__(newself):
-                return 'CombinedDistribution'
-            def sample(newself, t=None):
-                s1 = newself.d1.sample()
-                s2 = newself.d2.sample()
-                return s1 / s2
-        return CombinedDistribution(self, dist)
+        return CombinedDistribution(self, dist, truediv)
+
+
+class CombinedDistribution(Distribution):
+    """
+    A distribution that combines the samples of two other distributions, `dist1`
+    and `dist2`, using `operator`.
+    """
+
+    def __init__(self, dist1, dist2, operator):
+        self.d1 = copy.deepcopy(dist1)
+        self.d2 = copy.deepcopy(dist2)
+        self.operator = operator
+
+    def __repr__(self):
+        return 'CombinedDistribution'
+
+    def sample(self, t=None):
+        s1 = self.d1.sample()
+        s2 = self.d2.sample()
+        return self.operator(s1, s2)
 
 
 class Uniform(Distribution):

--- a/ciw/tests/test_node.py
+++ b/ciw/tests/test_node.py
@@ -1,6 +1,6 @@
 import unittest
 import ciw
-from hypothesis import given
+from hypothesis import given, settings
 from hypothesis.strategies import floats, integers, random_module
 
 class TestNode(unittest.TestCase):
@@ -682,6 +682,7 @@ class TestNode(unittest.TestCase):
         for srvr in Q.transitive_nodes[0].servers:
             self.assertGreaterEqual(srvr.total_time, srvr.busy_time)
 
+    @settings(deadline=None, max_examples=30)
     @given(lmbda=floats(min_value=0.01, max_value=10),
            mu=floats(min_value=0.01, max_value=10),
            c=integers(min_value=1, max_value=10),

--- a/ciw/tests/test_sampling.py
+++ b/ciw/tests/test_sampling.py
@@ -4,7 +4,7 @@ from csv import reader
 from random import random, choice
 from hypothesis import given
 from hypothesis.strategies import (floats, integers, lists,
-    random_module, assume, text)
+    random_module, text)
 import os
 import copy
 


### PR DESCRIPTION
At the request of @geraintpalmer, I've had a look at the PR. See the refactor of `ciw.dists.CombinedDistribution` in particular using the stdlib's `operator` module.

I also encountered a couple of errors when running the tests so have included their solutions in this PR.