### PR TITLE
Deadlock detectors and State trackers api change

### DIFF
--- a/ciw/__init__.py
+++ b/ciw/__init__.py
@@ -9,9 +9,9 @@ from .individual import Individual
 from .arrival_node import ArrivalNode
 from .exit_node import ExitNode
 from .node import Node
-from .state_tracker import *
 from .exactnode import *
 from .import_params import *
 from .network import *
-from .deadlock_detector import *
 import ciw.dists
+import ciw.deadlock
+import ciw.trackers

--- a/ciw/deadlock/__init__.py
+++ b/ciw/deadlock/__init__.py
@@ -1,0 +1,1 @@
+from .deadlock_detector import *

--- a/ciw/deadlock/deadlock_detector.py
+++ b/ciw/deadlock/deadlock_detector.py
@@ -1,6 +1,6 @@
 import networkx as nx
 
-class NoDeadlockDetection(object):
+class NoDetection(object):
     """
     A generic class for all deadlock detector classes to inherit from.
     Using this class is equivalent to having no deadlock detection
@@ -43,7 +43,7 @@ class NoDeadlockDetection(object):
         pass
 
 
-class StateDigraphMethod(NoDeadlockDetection):
+class StateDigraph(NoDetection):
     """
     The state digraph method keeps track of a directed graph of the
     simulation state, where:

--- a/ciw/tests/test_node.py
+++ b/ciw/tests/test_node.py
@@ -169,7 +169,7 @@ class TestNode(unittest.TestCase):
         ciw.seed(4)
         Q = ciw.Simulation(ciw.create_network_from_yml(
             'ciw/tests/testing_parameters/params_deadlock.yml'),
-            deadlock_detector='StateDigraph')
+            deadlock_detector=ciw.deadlock.StateDigraph())
         inds = [ciw.Individual(i + 1) for i in range(7)]
         N1 = Q.transitive_nodes[0]
         N1.individuals = [inds[:6]]
@@ -231,7 +231,7 @@ class TestNode(unittest.TestCase):
         ciw.seed(50)
         Q = ciw.Simulation(ciw.create_network_from_yml(
             'ciw/tests/testing_parameters/params_deadlock.yml'),
-            deadlock_detector='StateDigraph')
+            deadlock_detector=ciw.deadlock.StateDigraph())
         inds = [[ciw.Individual(i) for i in range(30)]]
         Q.transitive_nodes[0].individuals = inds
         ind = Q.transitive_nodes[0].individuals[0][0]
@@ -262,7 +262,7 @@ class TestNode(unittest.TestCase):
     def test_release_blocked_individual_method(self):
         Q = ciw.Simulation(ciw.create_network_from_yml(
             'ciw/tests/testing_parameters/params_deadlock.yml'),
-            deadlock_detector='StateDigraph')
+            deadlock_detector=ciw.deadlock.StateDigraph())
         N1 = Q.transitive_nodes[0]
         N2 = Q.transitive_nodes[1]
         N1.individuals = [[ciw.Individual(i) for i in range(N1.c + 3)]]
@@ -413,7 +413,7 @@ class TestNode(unittest.TestCase):
         ciw.seed(50)
         Q = ciw.Simulation(ciw.create_network_from_yml(
             'ciw/tests/testing_parameters/params_deadlock.yml'),
-            deadlock_detector='StateDigraph')
+            deadlock_detector=ciw.deadlock.StateDigraph())
         ind = ciw.Individual(1)
         self.assertEqual(set(Q.deadlock_detector.statedigraph.nodes()),
             set(['Server 5 at Node 2',

--- a/ciw/tests/test_server.py
+++ b/ciw/tests/test_server.py
@@ -65,7 +65,7 @@ class TestServer(unittest.TestCase):
             queue_capacities=[0],
             routing=[[1.0]]
         )
-        Q = ciw.Simulation(N, deadlock_detector='StateDigraph')
+        Q = ciw.Simulation(N, deadlock_detector=ciw.deadlock.StateDigraph())
         Q.simulate_until_deadlock()
         s = Q.nodes[1].servers[0]
         self.assertEqual(s.total_time, 4.0)

--- a/ciw/tests/test_simulation.py
+++ b/ciw/tests/test_simulation.py
@@ -202,14 +202,15 @@ class TestSimulation(unittest.TestCase):
         ciw.seed(3)
         Q = ciw.Simulation(ciw.create_network_from_yml(
             'ciw/tests/testing_parameters/params_deadlock.yml'),
-             deadlock_detector='StateDigraph')
+             deadlock_detector=ciw.deadlock.StateDigraph(),
+             tracker=ciw.trackers.NaiveTracker())
         Q.simulate_until_deadlock()
         self.assertEqual(round(Q.times_to_deadlock[((0, 0), (0, 0))], 8), 7.09795845)
 
     def test_detect_deadlock_method(self):
         Q = ciw.Simulation(ciw.create_network_from_yml(
             'ciw/tests/testing_parameters/params_deadlock.yml'),
-             deadlock_detector='StateDigraph')
+             deadlock_detector=ciw.deadlock.StateDigraph())
         nodes = ['A', 'B', 'C', 'D', 'E']
         connections = [('A', 'D'), ('A', 'B'), ('B', 'E'), ('C', 'B'), ('E', 'C')]
         Q.deadlock_detector.statedigraph = nx.DiGraph()
@@ -221,7 +222,7 @@ class TestSimulation(unittest.TestCase):
 
         Q = ciw.Simulation(ciw.create_network_from_yml(
             'ciw/tests/testing_parameters/params_deadlock.yml'),
-             deadlock_detector='StateDigraph')
+             deadlock_detector=ciw.deadlock.StateDigraph())
         nodes = ['A', 'B', 'C', 'D']
         connections = [('A', 'B'), ('A', 'C'), ('B', 'C'), ('B', 'D')]
         Q.deadlock_detector.statedigraph = nx.DiGraph()
@@ -233,7 +234,7 @@ class TestSimulation(unittest.TestCase):
 
         Q = ciw.Simulation(ciw.create_network_from_yml(
             'ciw/tests/testing_parameters/params_deadlock.yml'),
-             deadlock_detector='StateDigraph')
+             deadlock_detector=ciw.deadlock.StateDigraph())
         nodes = ['A', 'B']
         Q.deadlock_detector.statedigraph = nx.DiGraph()
         for nd in nodes:
@@ -732,11 +733,11 @@ class TestSimulation(unittest.TestCase):
         )
 
         ciw.seed(6)
-        Q = ciw.Simulation(N, deadlock_detector='StateDigraph')
+        Q = ciw.Simulation(N, deadlock_detector=ciw.deadlock.StateDigraph(),tracker=ciw.trackers.NaiveTracker())
         Q.simulate_until_deadlock()
         ttd = Q.times_to_deadlock[((0, 0), (0, 0))]
         self.assertEqual(round(ttd, 5), 92.49468)
 
     def test_generic_deadlock_detector(self):
-        DD = ciw.NoDeadlockDetection()
+        DD = ciw.deadlock.NoDetection()
         self.assertEqual(DD.detect_deadlock(), False)

--- a/ciw/tests/test_state_tracker.py
+++ b/ciw/tests/test_state_tracker.py
@@ -5,14 +5,16 @@ class TestStateTracker(unittest.TestCase):
     def test_base_init_method(self):
         Q = ciw.Simulation(ciw.create_network_from_yml(
           'ciw/tests/testing_parameters/params.yml'))
-        B = ciw.StateTracker(Q)
+        B = ciw.trackers.StateTracker()
+        B.initialise(Q)
         self.assertEqual(B.simulation, Q)
         self.assertEqual(B.state, None)
 
     def test_base_change_state_accept_method(self):
         Q = ciw.Simulation(ciw.create_network_from_yml(
           'ciw/tests/testing_parameters/params.yml'))
-        B = ciw.StateTracker(Q)
+        B = ciw.trackers.StateTracker()
+        B.initialise(Q)
         self.assertEqual(B.state, None)
         B.change_state_accept(1, 1)
         self.assertEqual(B.state, None)
@@ -20,7 +22,8 @@ class TestStateTracker(unittest.TestCase):
     def test_base_change_state_block_method(self):
         Q = ciw.Simulation(ciw.create_network_from_yml(
           'ciw/tests/testing_parameters/params.yml'))
-        B = ciw.StateTracker(Q)
+        B = ciw.trackers.StateTracker()
+        B.initialise(Q)
         self.assertEqual(B.state, None)
         B.change_state_block(1, 1, 1)
         self.assertEqual(B.state, None)
@@ -28,7 +31,8 @@ class TestStateTracker(unittest.TestCase):
     def test_base_change_state_release_method(self):
         Q = ciw.Simulation(ciw.create_network_from_yml(
           'ciw/tests/testing_parameters/params.yml'))
-        B = ciw.StateTracker(Q)
+        B = ciw.trackers.StateTracker()
+        B.initialise(Q)
         self.assertEqual(B.state, None)
         B.change_state_release(1, 1, 1, True)
         self.assertEqual(B.state, None)
@@ -36,7 +40,8 @@ class TestStateTracker(unittest.TestCase):
     def test_base_hash_state_method(self):
         Q = ciw.Simulation(ciw.create_network_from_yml(
           'ciw/tests/testing_parameters/params.yml'))
-        B = ciw.StateTracker(Q)
+        B = ciw.trackers.StateTracker()
+        B.initialise(Q)
         self.assertEqual(B.hash_state(), None)
 
     def test_base_release_method_within_simulation(self):
@@ -86,14 +91,16 @@ class TestNaiveTracker(unittest.TestCase):
     def test_naive_init_method(self):
         Q = ciw.Simulation(ciw.create_network_from_yml(
           'ciw/tests/testing_parameters/params.yml'))
-        B = ciw.NaiveTracker(Q)
+        B = ciw.trackers.NaiveTracker()
+        B.initialise(Q)
         self.assertEqual(B.simulation, Q)
         self.assertEqual(B.state, [[0, 0], [0, 0], [0, 0], [0, 0]])
 
     def test_naive_change_state_accept_method(self):
         Q = ciw.Simulation(ciw.create_network_from_yml(
           'ciw/tests/testing_parameters/params.yml'))
-        B = ciw.NaiveTracker(Q)
+        B = ciw.trackers.NaiveTracker()
+        B.initialise(Q)
         self.assertEqual(B.state, [[0, 0], [0, 0], [0, 0], [0, 0]])
         B.change_state_accept(1, 1)
         self.assertEqual(B.state, [[1, 0], [0, 0], [0, 0], [0, 0]])
@@ -101,7 +108,8 @@ class TestNaiveTracker(unittest.TestCase):
     def test_naive_change_state_block_method(self):
         Q = ciw.Simulation(ciw.create_network_from_yml(
           'ciw/tests/testing_parameters/params.yml'))
-        B = ciw.NaiveTracker(Q)
+        B = ciw.trackers.NaiveTracker()
+        B.initialise(Q)
         B.state = [[1, 0], [0, 0], [0, 0], [0, 0]]
         B.change_state_block(1, 1, 2)
         self.assertEqual(B.state, [[0, 1], [0, 0], [0, 0], [0, 0]])
@@ -109,7 +117,8 @@ class TestNaiveTracker(unittest.TestCase):
     def test_naive_change_state_release_method(self):
         Q = ciw.Simulation(ciw.create_network_from_yml(
           'ciw/tests/testing_parameters/params.yml'))
-        B = ciw.NaiveTracker(Q)
+        B = ciw.trackers.NaiveTracker()
+        B.initialise(Q)
         B.state = [[2, 1], [3, 0], [1, 0], [4, 4]]
         B.change_state_release(1, 1, 2, False)
         self.assertEqual(B.state, [[1, 1], [3, 0], [1, 0], [4, 4]])
@@ -119,14 +128,15 @@ class TestNaiveTracker(unittest.TestCase):
     def test_naive_hash_state_method(self):
         Q = ciw.Simulation(ciw.create_network_from_yml(
           'ciw/tests/testing_parameters/params.yml'))
-        B = ciw.NaiveTracker(Q)
+        B = ciw.trackers.NaiveTracker()
+        B.initialise(Q)
         B.state = [[3, 4], [1, 2], [0, 1], [0, 0]]
         self.assertEqual(B.hash_state(), ((3, 4), (1, 2), (0, 1), (0, 0)))
 
     def test_naive_release_method_within_simulation(self):
         params = ciw.create_network_from_yml(
             'ciw/tests/testing_parameters/params.yml')
-        Q = ciw.Simulation(params, tracker='Naive')
+        Q = ciw.Simulation(params, tracker=ciw.trackers.NaiveTracker())
         N = Q.transitive_nodes[2]
         inds = [ciw.Individual(i) for i in range(5)]
         N.individuals = [inds]
@@ -148,7 +158,7 @@ class TestNaiveTracker(unittest.TestCase):
     def test_naive_block_method_within_simulation(self):
         params = ciw.create_network_from_yml(
             'ciw/tests/testing_parameters/params.yml')
-        Q = ciw.Simulation(params, tracker='Naive')
+        Q = ciw.Simulation(params, tracker=ciw.trackers.NaiveTracker())
         N = Q.transitive_nodes[2]
         Q.statetracker.state = [[4, 1], [3, 0], [5, 1], [0, 0]]
         self.assertEqual(Q.statetracker.state, [[4, 1], [3, 0], [5, 1], [0, 0]])
@@ -158,7 +168,7 @@ class TestNaiveTracker(unittest.TestCase):
     def test_naive_accept_method_within_simulation(self):
         params = ciw.create_network_from_yml(
             'ciw/tests/testing_parameters/params.yml')
-        Q = ciw.Simulation(params, tracker='Naive')
+        Q = ciw.Simulation(params, tracker=ciw.trackers.NaiveTracker())
         N = Q.transitive_nodes[2]
         self.assertEqual(Q.statetracker.state, [[0, 0], [0, 0], [0, 0], [0, 0]])
         Q.current_time = 45.6
@@ -172,7 +182,8 @@ class TestMatrixTracker(unittest.TestCase):
     def test_matrix_init_method(self):
         Q = ciw.Simulation(ciw.create_network_from_yml(
           'ciw/tests/testing_parameters/params.yml'))
-        B = ciw.MatrixTracker(Q)
+        B = ciw.trackers.MatrixTracker()
+        B.initialise(Q)
         self.assertEqual(B.simulation, Q)
         self.assertEqual(B.state, [[[[], [], [], []],
                                     [[], [], [], []],
@@ -183,7 +194,8 @@ class TestMatrixTracker(unittest.TestCase):
     def test_matrix_change_state_accept_method(self):
         Q = ciw.Simulation(ciw.create_network_from_yml(
           'ciw/tests/testing_parameters/params.yml'))
-        B = ciw.MatrixTracker(Q)
+        B = ciw.trackers.MatrixTracker()
+        B.initialise(Q)
         self.assertEqual(B.state, [[[[], [], [], []],
                                     [[], [], [], []],
                                     [[], [], [], []],
@@ -199,7 +211,8 @@ class TestMatrixTracker(unittest.TestCase):
     def test_matrix_change_state_block_method(self):
         Q = ciw.Simulation(ciw.create_network_from_yml(
           'ciw/tests/testing_parameters/params.yml'))
-        B = ciw.MatrixTracker(Q)
+        B = ciw.trackers.MatrixTracker()
+        B.initialise(Q)
         B.state = [[[[], [], [], []],
                     [[], [], [], []],
                     [[], [], [], []],
@@ -227,7 +240,8 @@ class TestMatrixTracker(unittest.TestCase):
     def test_matrix_change_state_release_method(self):
         Q = ciw.Simulation(ciw.create_network_from_yml(
           'ciw/tests/testing_parameters/params.yml'))
-        B = ciw.MatrixTracker(Q)
+        B = ciw.trackers.MatrixTracker()
+        B.initialise(Q)
         B.state = [[[[],  [], [1, 3], []],
                     [[2], [], [],     []],
                     [[],  [], [],     []],
@@ -249,7 +263,8 @@ class TestMatrixTracker(unittest.TestCase):
     def test_matrix_hash_state_method(self):
         Q = ciw.Simulation(ciw.create_network_from_yml(
           'ciw/tests/testing_parameters/params.yml'))
-        B = ciw.MatrixTracker(Q)
+        B = ciw.trackers.MatrixTracker()
+        B.initialise(Q)
         B.state = [[[[],  [], [1, 3], []],
                     [[2], [], [],     []],
                     [[],  [], [],     []],
@@ -264,7 +279,7 @@ class TestMatrixTracker(unittest.TestCase):
     def test_matrix_release_method_within_simulation(self):
         params = ciw.create_network_from_yml(
             'ciw/tests/testing_parameters/params.yml')
-        Q = ciw.Simulation(params, tracker='Matrix')
+        Q = ciw.Simulation(params, tracker=ciw.trackers.MatrixTracker())
         N = Q.transitive_nodes[2]
         inds = [ciw.Individual(i) for i in range(5)]
         N.individuals = [inds]
@@ -308,7 +323,7 @@ class TestMatrixTracker(unittest.TestCase):
     def test_matrix_block_method_within_simulation(self):
         params = ciw.create_network_from_yml(
             'ciw/tests/testing_parameters/params.yml')
-        Q = ciw.Simulation(params, tracker='Matrix')
+        Q = ciw.Simulation(params, tracker=ciw.trackers.MatrixTracker())
         N = Q.transitive_nodes[2]
         Q.statetracker.state = [[[[],  [2], [], []],
                                  [[],  [],  [], []],
@@ -331,7 +346,7 @@ class TestMatrixTracker(unittest.TestCase):
     def test_matrix_accept_method_within_simulation(self):
         params = ciw.create_network_from_yml(
             'ciw/tests/testing_parameters/params.yml')
-        Q = ciw.Simulation(params, tracker='Matrix')
+        Q = ciw.Simulation(params, tracker=ciw.trackers.MatrixTracker())
         N = Q.transitive_nodes[2]
         self.assertEqual(Q.statetracker.state, [[[[], [], [], []],
                                                  [[], [], [], []],

--- a/ciw/trackers/__init__.py
+++ b/ciw/trackers/__init__.py
@@ -1,0 +1,1 @@
+from .state_tracker import *

--- a/ciw/trackers/state_tracker.py
+++ b/ciw/trackers/state_tracker.py
@@ -4,7 +4,7 @@ class StateTracker(object):
     """
     A generic class to record system's state.
     """
-    def __init__(self, simulation):
+    def initialise(self, simulation):
         """
         Initialises the state tracker class.
         """
@@ -47,7 +47,7 @@ class NaiveTracker(StateTracker):
         are blocked, 5 customers at the second node, 4 of which
         are blocked.
     """
-    def __init__(self, simulation):
+    def initialise(self, simulation):
         """
         Initialises the naive tracker class.
         """
@@ -100,7 +100,7 @@ class MatrixTracker(StateTracker):
         the second node to the first. The numbers denote the order
         at which they became blocked.
     """
-    def __init__(self, simulation):
+    def initialise(self, simulation):
         """
         Initialises the naive tracker class.
         """

--- a/docs/Guides/deadlock.rst
+++ b/docs/Guides/deadlock.rst
@@ -19,7 +19,7 @@ Ciw then records the time until deadlock from each state.
 (Please see the documentation on :ref:`state trackers <state-trackers>`.)
 
 In order to take advantage of this feature, set the :code:`deadlock_detection` argument to one of the deadlock detection methods when creating the Simulation object.
-Currently only :code:`'StateDigraph'` is implemented.
+Currently only :code:`ciw.deadlock.StateDigraph` is implemented.
 Then use the :code:`simulate_until_deadlock` method.
 The attribute :code:`times_to_deadlock` contains the times to deadlock from each state.
 
@@ -37,11 +37,14 @@ Parameters::
     ...    queue_capacities=[3]
     ... )
 
-Running until deadlock::
+Running until deadlock (using a :code:`ciw.trackers.NaiveTracker` object)::
 
     >>> import ciw
     >>> ciw.seed(1)
-    >>> Q = ciw.Simulation(N, deadlock_detector='StateDigraph')
+    >>> Q = ciw.Simulation(N,
+    ...     deadlock_detector=ciw.deadlock.StateDigraph(),
+    ...     tracker=ciw.trackers.NaiveTracker()
+    ... )
     >>> Q.simulate_until_deadlock()
     >>> Q.times_to_deadlock # doctest:+SKIP
     {((0, 0),): 0.94539784..., ((1, 0),): 0.92134933..., ((2, 0),): 0.68085451..., ((3, 0),): 0.56684471..., ((3, 1),): 0.0, ((4, 0),): 0.25332344...}
@@ -56,7 +59,8 @@ How to Set a State Tracker
 ==========================
 
 Ciw has the option to activate a state :code:`tracker` in order to track the state of the system as the simulation progresses towards deadlock.
-The default is the basic :code:`StateTracker` which does nothing (unless the simulation is detecting deadlock, in which case :code:`NaiveTracker` is the default).
+In the example above a :code:`NaiveTracker` was used.
+The default is the basic :code:`StateTracker` which does nothing.
 The state trackers have their uses when simulating until deadlock, as a time to deadlock is recorded for every state the simulation reaches.
 
 For a list and explanation of the state trackers that Ciw currently supports see :ref:`refs-statetrackers`.
@@ -75,7 +79,10 @@ Simulating until deadlock, the :code:`times_to_deadlock` dictionary will contain
     ... )
 
     >>> ciw.seed(1)
-    >>> Q = ciw.Simulation(N, deadlock_detector='StateDigraph', tracker='Naive')
+    >>> Q = ciw.Simulation(N,
+    ...     deadlock_detector=ciw.deadlock.StateDigraph(),
+    ...     tracker=ciw.trackers.NaiveTracker()
+    ... )
     >>> Q.simulate_until_deadlock()
     >>> Q.times_to_deadlock # doctest:+SKIP
     {((0, 0),): 1.3354..., ((1, 0),): 1.3113..., ((1, 2),): 0.0, ((2, 0),): 1.0708..., ((2, 1),): 0.9353..., ((3, 0),): 0.9568...}
@@ -83,10 +90,13 @@ Simulating until deadlock, the :code:`times_to_deadlock` dictionary will contain
 The following states are expected if a Matrix Tracker is used: ((()), (0)), ((()), (1)), ((()), (2)), ((()), (3)), (((1)), (3)), (((1, 2)), (3)).
 
     >>> ciw.seed(1)
-    >>> Q = ciw.Simulation(N, deadlock_detector='StateDigraph', tracker='Matrix')
+    >>> Q = ciw.Simulation(N,
+    ...     deadlock_detector=ciw.deadlock.StateDigraph(),
+    ...     tracker=ciw.trackers.MatrixTracker()
+    ... )
     >>> Q.simulate_until_deadlock()
     >>> Q.times_to_deadlock # doctest:+SKIP
     {((((),),), (0,)): 1.3354..., ((((),),), (1,)): 1.3113..., ((((),),), (2,)): 1.0708..., ((((),),), (3,)): 0.9568..., ((((1,),),), (3,)): 0.9353..., ((((1, 2),),), (3,)): 0.0}
 
-Notice that in this simple case, the Naive and Matric trackers correspond to the same states.
+Notice that in this simple case, the Naive and Matrix trackers correspond to the same states.
 In other examples, where customers may get blocked in different orders and to different places, then the two trackers may track different system states.

--- a/docs/Reference/state_trackers.rst
+++ b/docs/Reference/state_trackers.rst
@@ -25,7 +25,7 @@ This denotes 3 customers at the first node, 0 of which are blocked; 5 customers 
 
 The Simulation object takes in the optional argument :code:`tracker` used as follows::
 
-    >>> Q = ciw.Simulation(N, tracker='Naive') # doctest:+SKIP
+    >>> Q = ciw.Simulation(N, tracker=ciw.trackers.NaiveTracker()) # doctest:+SKIP
 
 
 .. _matrix:
@@ -62,4 +62,4 @@ It also tells us the order and destination of the blockages:
 
 The Simulation object takes in the optional argument :code:`tracker` used as follows::
 
-    >>> Q = ciw.Simulation(N, tracker='Matrix') # doctest:+SKIP
+    >>> Q = ciw.Simulation(N, tracker=ciw.trackers.MatrixTracker()) # doctest:+SKIP


### PR DESCRIPTION
+ Deadlock detectors in sublibrary `deadlock`
+ State trackers in sublibrary `trackers`
+ Implemented by inputting the objects into the Simulation object
+ Remove string inputs
+ If deadlock detector selected, no state tracker is given used as default