### PR TITLE
Apply several microoptimizations for a >20% reduction in simulation run time

### DIFF
--- a/ciw/arrival_node.py
+++ b/ciw/arrival_node.py
@@ -51,16 +51,18 @@ class ArrivalNode(object):
         """
         Finds the time of the next arrival.
         """
-        times = [[self.event_dates_dict[nd + 1][clss]
-            for clss in range(len(self.event_dates_dict[1]))]
-            for nd in range(len(self.event_dates_dict))]
-
-        mintimes = [min(obs) for obs in times]
-        nd = mintimes.index(min(mintimes))
-        clss = times[nd].index(min(times[nd]))
-        self.next_node = nd + 1
-        self.next_class = clss
-        self.next_event_date = self.event_dates_dict[self.next_node][self.next_class]
+        minnd = None
+        minclss = None
+        mindate = float("Inf")
+        for nd in self.event_dates_dict:
+            for clss in self.event_dates_dict[nd]:
+                if self.event_dates_dict[nd][clss] < mindate:
+                    minnd = nd
+                    minclss = clss
+                    mindate = self.event_dates_dict[nd][clss]
+        self.next_node = minnd
+        self.next_class = minclss
+        self.next_event_date = mindate
 
     def have_event(self):
         """

--- a/ciw/node.py
+++ b/ciw/node.py
@@ -123,13 +123,14 @@ class Node(object):
           - attach server to individual
         """
         next_individual.arrival_date = self.get_now()
-        if self.free_server():
+        free_server = self.find_free_server()
+        if free_server is not None or isinf(self.c):
             next_individual.service_start_date = self.get_now()
             next_individual.service_time = self.get_service_time(next_individual)
             next_individual.service_end_date = self.increment_time(
                 self.get_now(), next_individual.service_time)
-            if not isinf(self.c):
-                self.attach_server(self.find_free_server(), next_individual)
+            if free_server is not None:
+                self.attach_server(free_server, next_individual)
 
     def begin_interrupted_individuals_service(self, srvr):
         """
@@ -182,8 +183,8 @@ class Node(object):
           - give a start date and end date
           - attach server to individual
         """
-        if self.free_server() and (not isinf(self.c)):
-            srvr = self.find_free_server()
+        srvr = self.find_free_server()
+        if srvr is not None:
             if self.number_interrupted_individuals > 0:
                 self.begin_interrupted_individuals_service(srvr)
             else:
@@ -284,17 +285,18 @@ class Node(object):
         """
         Returns True if a server is available, False otherwise.
         """
-        if isinf(self.c):
-            return True
-        return len([svr for svr in self.servers if not svr.busy]) > 0
+        return isinf(self.c) or self.find_free_server() is not None
 
     def find_free_server(self):
         """
         Finds a free server.
         """
+        if isinf(self.c):
+            return None
         for svr in self.servers:
             if not svr.busy:
                 return svr
+        return None
 
     def find_next_individual(self):
         """

--- a/ciw/node.py
+++ b/ciw/node.py
@@ -489,13 +489,16 @@ class Node(object):
           - otherwise return minimum of next shift change, and time for
             next individual (who isn't blocked) to end service, or Inf
         """
+        next_end_service = float("Inf")
         if not isinf(self.c):
-            next_end_service = min([s.next_end_service_date
-                for s in self.servers] + [float("Inf")])
+            for s in self.servers:
+                if s.next_end_service_date < next_end_service:
+                    next_end_service = s.next_end_service_date
         else:
-            next_end_service = min([ind.service_end_date
-                for ind in self.all_individuals if not ind.is_blocked
-                if ind.service_end_date >= self.get_now()] + [float("Inf")])
+            for ind in self.all_individuals:
+                if not ind.is_blocked and ind.service_end_date >= self.get_now():
+                    if ind.service_end_date < next_end_service:
+                        next_end_service = ind.service_end_date
         if self.schedule:
             next_shift_change = self.next_shift_change
             self.next_event_date = min(next_end_service, next_shift_change)

--- a/ciw/node.py
+++ b/ciw/node.py
@@ -69,6 +69,8 @@ class Node(object):
 
     @property
     def all_individuals(self):
+        if self.simulation.number_of_priority_classes == 1:
+            return self.individuals[0]
         return flatten_list(self.individuals)
 
     def __repr__(self):

--- a/ciw/node.py
+++ b/ciw/node.py
@@ -166,14 +166,14 @@ class Node(object):
             if self.number_interrupted_individuals > 0:
                 self.begin_interrupted_individuals_service(srvr)
             else:
-                inds_without_server = [i for i in self.all_individuals if not i.server]
-                if len(inds_without_server) > 0:
-                    ind = inds_without_server[0]
-                    ind.service_start_date = self.get_now()
-                    ind.service_time = self.get_service_time(ind)
-                    ind.service_end_date = self.increment_time(
-                        ind.service_start_date, ind.service_time)
-                    self.attach_server(srvr, ind)
+                for ind in self.all_individuals:
+                    if not ind.server:
+                        ind.service_start_date = self.get_now()
+                        ind.service_time = self.get_service_time(ind)
+                        ind.service_end_date = self.increment_time(
+                            ind.service_start_date, ind.service_time)
+                        self.attach_server(srvr, ind)
+                        break
 
     def begin_service_if_possible_release(self):
         """
@@ -190,14 +190,14 @@ class Node(object):
             if self.number_interrupted_individuals > 0:
                 self.begin_interrupted_individuals_service(srvr)
             else:
-                inds_without_server = [i for i in self.all_individuals if not i.server]
-                if len(inds_without_server) > 0:
-                    ind = inds_without_server[0]
-                    ind.service_start_date = self.get_now()
-                    ind.service_time = self.get_service_time(ind)
-                    ind.service_end_date = self.increment_time(
-                        ind.service_start_date, ind.service_time)
-                    self.attach_server(srvr, ind)
+                for ind in self.all_individuals:
+                    if not ind.server:
+                        ind.service_start_date = self.get_now()
+                        ind.service_time = self.get_service_time(ind)
+                        ind.service_end_date = self.increment_time(
+                            ind.service_start_date, ind.service_time)
+                        self.attach_server(srvr, ind)
+                        break
 
     def block_individual(self, individual, next_node):
         """

--- a/ciw/simulation.py
+++ b/ciw/simulation.py
@@ -100,9 +100,14 @@ class Simulation(object):
         """
         Returns the next active node, the node whose next_event_date is next:
         """
-        next_event_date = min([nd.next_event_date for nd in self.nodes])
-        next_active_nodes = [nd for nd in self.nodes
-            if nd.next_event_date == next_event_date]
+        mindate = float("Inf")
+        next_active_nodes = []
+        for nd in self.nodes:
+            if nd.next_event_date < mindate:
+                mindate = nd.next_event_date
+                next_active_nodes = [nd]
+            elif nd.next_event_date == mindate:
+                next_active_nodes.append(nd)
         if len(next_active_nodes) > 1:
             return random_choice(next_active_nodes)
         return next_active_nodes[0]

--- a/ciw/simulation.py
+++ b/ciw/simulation.py
@@ -101,11 +101,11 @@ class Simulation(object):
         Returns the next active node, the node whose next_event_date is next:
         """
         next_event_date = min([nd.next_event_date for nd in self.nodes])
-        next_active_node_indices = [i for i, nd in enumerate(
-            self.nodes) if nd.next_event_date == next_event_date]
-        if len(next_active_node_indices) > 1:
-            return self.nodes[random_choice(next_active_node_indices)]
-        return self.nodes[next_active_node_indices[0]]
+        next_active_nodes = [nd for nd in self.nodes
+            if nd.next_event_date == next_event_date]
+        if len(next_active_nodes) > 1:
+            return random_choice(next_active_nodes)
+        return next_active_nodes[0]
 
     def get_all_individuals(self):
         """


### PR DESCRIPTION
Thank you for this outstanding library! The documentation, nicely structured and with easy to follow examples, is a delight compared to other packages for queue simulation I have experimented with.

My machine is a bit underpowered and some of the simulations I want to run take a significant amount of time to complete (over half a minute for 1m customers).

I ran a profiler to see if there are any hot spots that could be optimized and found several. A few microoptimizations introduced in this PR reduce the simulation run time by more than 20%:

```
> python3 -m timeit -s 'from bench import simulate' 'simulate(1_000_000)'
Ciw version: 2.0.1
1 loop, best of 5: 38.9 sec per loop

> python3 -m timeit -s 'from bench import simulate' 'simulate(1_000_000)'
Ciw version: 2.0.1-patched
1 loop, best of 5: 29.6 sec per loop
```

(The benchmark runs an M/M/3/10 model for 1,000,000 customers. The code is available [here](https://gist.github.com/timlathy/676f5a7b2da20bf37a0716e4071e6f5e), along with a Jupyter Notebook I used for visualizing profiler traces).

The changes don't break APIs and only affect the implementation of several frequently invoked functions. I tried to keep commit messages as informative as possible. If you have any suggestions or corrections, I'm open to discussion and ready to make the necessary changes.