### PR TITLE
Update state tracking

### DIFF
--- a/ciw/tests/test_state_tracker.py
+++ b/ciw/tests/test_state_tracker.py
@@ -789,29 +789,20 @@ class TestTrackHistory(unittest.TestCase):
         [Decimal('0.0'), (0,)],
         [Decimal('0.31'), (1,)],
         [Decimal('0.62'), (2,)],
-        [Decimal('0.71'), (2,)],
         [Decimal('0.93'), (3,)],
         [Decimal('1.24'), (4,)],
         [Decimal('1.31'), (3,)],
-        [Decimal('1.42'), (3,)],
         [Decimal('1.55'), (4,)],
-        [Decimal('1.71'), (4,)],
         [Decimal('1.86'), (5,)],
-        [Decimal('2.13'), (5,)],
         [Decimal('2.17'), (6,)],
         [Decimal('2.31'), (5,)],
         [Decimal('2.48'), (6,)],
-        [Decimal('2.71'), (6,)],
         [Decimal('2.79'), (7,)],
-        [Decimal('2.84'), (7,)],
         [Decimal('3.10'), (8,)],
         [Decimal('3.31'), (7,)],
         [Decimal('3.41'), (8,)],
-        [Decimal('3.55'), (8,)],
-        [Decimal('3.71'), (8,)],
         [Decimal('3.72'), (9,)],
         [Decimal('4.03'), (10,)],
-        [Decimal('4.26'), (10,)],
         [Decimal('4.31'), (9,)],
         [Decimal('4.34'), (10,)]
         ]
@@ -823,33 +814,36 @@ class TestTrackHistory(unittest.TestCase):
         Q.simulate_until_max_time(4.5)
         expected_history = [
         [Decimal('0.0'), (0,)],
-        [Decimal('0.31'), (0,)],
-        [Decimal('0.62'), (0,)],
         [Decimal('0.71'), (1,)],
-        [Decimal('0.93'), (1,)],
-        [Decimal('1.24'), (1,)],
         [Decimal('1.31'), (2,)],
         [Decimal('1.42'), (3,)],
-        [Decimal('1.55'), (3,)],
         [Decimal('1.71'), (2,)],
-        [Decimal('1.86'), (2,)],
         [Decimal('2.13'), (3,)],
-        [Decimal('2.17'), (3,)],
         [Decimal('2.31'), (4,)],
-        [Decimal('2.48'), (4,)],
         [Decimal('2.71'), (3,)],
-        [Decimal('2.79'), (3,)],
         [Decimal('2.84'), (4,)],
-        [Decimal('3.10'), (4,)],
         [Decimal('3.31'), (5,)],
-        [Decimal('3.41'), (5,)],
         [Decimal('3.55'), (6,)],
         [Decimal('3.71'), (5,)],
-        [Decimal('3.72'), (5,)],
-        [Decimal('4.03'), (5,)],
         [Decimal('4.26'), (6,)],
-        [Decimal('4.31'), (7,)],
-        [Decimal('4.34'), (7,)]
+        [Decimal('4.31'), (7,)]
+        ]
+        self.assertEqual(Q.statetracker.history, expected_history)
+
+    def test_no_state_change_when_blocking_subset(self):
+        N = ciw.create_network(
+            arrival_distributions=[ciw.dists.Deterministic(1), ciw.dists.NoArrivals()],
+            service_distributions=[ciw.dists.Deterministic(0.1), ciw.dists.Deterministic(1.2)],
+            number_of_servers=[1, 1],
+            routing=[[0.0, 1.0], [0.0, 0.0]],
+            queue_capacities=[float('Inf'), 0]
+        )
+        B = ciw.trackers.NodePopulationSubset([1])
+        Q = ciw.Simulation(N, tracker=B, exact=26)
+        Q.simulate_until_max_time(15.5)
+        expected_history = [
+        [Decimal('0.0'), (0,)],
+        [Decimal('1.1'), (1,)]
         ]
         self.assertEqual(Q.statetracker.history, expected_history)
 
@@ -913,10 +907,8 @@ class TestTrackHistory(unittest.TestCase):
             [0.00, 0],
             [0.60, 1],
             [1.09, 2],
-            [1.32, 2],
             [1.64, 3],
             [1.96, 2],
-            [2.67, 2],
             [2.84, 3],
             [3.39, 4],
             [3.41, 5],
@@ -940,10 +932,8 @@ class TestTrackHistory(unittest.TestCase):
             [0.00, (0, 0)],
             [0.60, (0, 1)],
             [1.09, (0, 2)],
-            [1.32, (0, 2)],
             [1.64, (0, 3)],
             [1.96, (0, 2)],
-            [2.67, (0, 2)],
             [2.84, (1, 2)],
             [3.39, (1, 3)],
             [3.41, (2, 3)],
@@ -967,10 +957,8 @@ class TestTrackHistory(unittest.TestCase):
             [0.00, ((0, 0), (0, 0))],
             [0.60, ((0, 0), (0, 1))],
             [1.09, ((0, 0), (1, 1))],
-            [1.32, ((0, 0), (1, 1))],
             [1.64, ((0, 0), (1, 2))],
             [1.96, ((0, 0), (0, 2))],
-            [2.67, ((0, 0), (0, 2))],
             [2.84, ((0, 1), (0, 2))],
             [3.39, ((0, 1), (0, 3))],
             [3.41, ((0, 2), (0, 3))],

--- a/ciw/tests/test_state_tracker.py
+++ b/ciw/tests/test_state_tracker.py
@@ -736,6 +736,124 @@ class TestTrackHistory(unittest.TestCase):
         ]
         self.assertEqual(Q.statetracker.history, expected_history)
 
+
+    def test_two_node_deterministic_nodepopulationsubset(self):
+        N = ciw.create_network(
+            arrival_distributions=[ciw.dists.Deterministic(0.31), ciw.dists.Deterministic(0.71)],
+            service_distributions=[ciw.dists.Deterministic(1), ciw.dists.Deterministic(1)],
+            routing=[[0.0, 1.0], [0.0, 0.0]],
+            number_of_servers=[1, 1]
+        )
+
+        # First with Both nodes
+        B = ciw.trackers.NodePopulationSubset([0, 1])
+        Q = ciw.Simulation(N, tracker=B, exact=26)
+        Q.simulate_until_max_time(4.5)
+        expected_history = [
+        [Decimal('0.0'), (0, 0)],
+        [Decimal('0.31'), (1, 0)],
+        [Decimal('0.62'), (2, 0)],
+        [Decimal('0.71'), (2, 1)],
+        [Decimal('0.93'), (3, 1)],
+        [Decimal('1.24'), (4, 1)],
+        [Decimal('1.31'), (3, 2)],
+        [Decimal('1.42'), (3, 3)],
+        [Decimal('1.55'), (4, 3)],
+        [Decimal('1.71'), (4, 2)],
+        [Decimal('1.86'), (5, 2)],
+        [Decimal('2.13'), (5, 3)],
+        [Decimal('2.17'), (6, 3)],
+        [Decimal('2.31'), (5, 4)],
+        [Decimal('2.48'), (6, 4)],
+        [Decimal('2.71'), (6, 3)],
+        [Decimal('2.79'), (7, 3)],
+        [Decimal('2.84'), (7, 4)],
+        [Decimal('3.10'), (8, 4)],
+        [Decimal('3.31'), (7, 5)],
+        [Decimal('3.41'), (8, 5)],
+        [Decimal('3.55'), (8, 6)],
+        [Decimal('3.71'), (8, 5)],
+        [Decimal('3.72'), (9, 5)],
+        [Decimal('4.03'), (10, 5)],
+        [Decimal('4.26'), (10, 6)],
+        [Decimal('4.31'), (9, 7)],
+        [Decimal('4.34'), (10, 7)]
+        ]
+        self.assertEqual(Q.statetracker.history, expected_history)
+
+        # First with then 1st only
+        B = ciw.trackers.NodePopulationSubset([0])
+        Q = ciw.Simulation(N, tracker=B, exact=26)
+        Q.simulate_until_max_time(4.5)
+        expected_history = [
+        [Decimal('0.0'), (0,)],
+        [Decimal('0.31'), (1,)],
+        [Decimal('0.62'), (2,)],
+        [Decimal('0.71'), (2,)],
+        [Decimal('0.93'), (3,)],
+        [Decimal('1.24'), (4,)],
+        [Decimal('1.31'), (3,)],
+        [Decimal('1.42'), (3,)],
+        [Decimal('1.55'), (4,)],
+        [Decimal('1.71'), (4,)],
+        [Decimal('1.86'), (5,)],
+        [Decimal('2.13'), (5,)],
+        [Decimal('2.17'), (6,)],
+        [Decimal('2.31'), (5,)],
+        [Decimal('2.48'), (6,)],
+        [Decimal('2.71'), (6,)],
+        [Decimal('2.79'), (7,)],
+        [Decimal('2.84'), (7,)],
+        [Decimal('3.10'), (8,)],
+        [Decimal('3.31'), (7,)],
+        [Decimal('3.41'), (8,)],
+        [Decimal('3.55'), (8,)],
+        [Decimal('3.71'), (8,)],
+        [Decimal('3.72'), (9,)],
+        [Decimal('4.03'), (10,)],
+        [Decimal('4.26'), (10,)],
+        [Decimal('4.31'), (9,)],
+        [Decimal('4.34'), (10,)]
+        ]
+        self.assertEqual(Q.statetracker.history, expected_history)
+
+        # Then 2nd only
+        B = ciw.trackers.NodePopulationSubset([1])
+        Q = ciw.Simulation(N, tracker=B, exact=26)
+        Q.simulate_until_max_time(4.5)
+        expected_history = [
+        [Decimal('0.0'), (0,)],
+        [Decimal('0.31'), (0,)],
+        [Decimal('0.62'), (0,)],
+        [Decimal('0.71'), (1,)],
+        [Decimal('0.93'), (1,)],
+        [Decimal('1.24'), (1,)],
+        [Decimal('1.31'), (2,)],
+        [Decimal('1.42'), (3,)],
+        [Decimal('1.55'), (3,)],
+        [Decimal('1.71'), (2,)],
+        [Decimal('1.86'), (2,)],
+        [Decimal('2.13'), (3,)],
+        [Decimal('2.17'), (3,)],
+        [Decimal('2.31'), (4,)],
+        [Decimal('2.48'), (4,)],
+        [Decimal('2.71'), (3,)],
+        [Decimal('2.79'), (3,)],
+        [Decimal('2.84'), (4,)],
+        [Decimal('3.10'), (4,)],
+        [Decimal('3.31'), (5,)],
+        [Decimal('3.41'), (5,)],
+        [Decimal('3.55'), (6,)],
+        [Decimal('3.71'), (5,)],
+        [Decimal('3.72'), (5,)],
+        [Decimal('4.03'), (5,)],
+        [Decimal('4.26'), (6,)],
+        [Decimal('4.31'), (7,)],
+        [Decimal('4.34'), (7,)]
+        ]
+        self.assertEqual(Q.statetracker.history, expected_history)
+
+
     def test_one_node_deterministic_nodeclassmatrix(self):
         N = ciw.create_network(
             arrival_distributions=[ciw.dists.Sequential([1.5, 0.3, 2.4, 1.1])],

--- a/ciw/trackers/state_tracker.py
+++ b/ciw/trackers/state_tracker.py
@@ -177,6 +177,63 @@ class NodePopulation(StateTracker):
         return tuple(self.state)
 
 
+class NodePopulationSubset(StateTracker):
+    """
+    The node population tracker records the number of customers at each node
+    from a given set of observed nodes.
+
+    Example:
+        (3, 1)
+        This denotes 3 customers at the first node, and 1 customer at the
+        second node.
+    """
+    def __init__(self, observed_nodes):
+        """
+        Pre-initialises the object with keyward `observed_nodes`
+        """
+        self.observed_nodes = observed_nodes
+
+    def initialise(self, simulation):
+        """
+        Initialises the state tracker class.
+        """
+        self.simulation = simulation
+        self.state = [0 for i in self.observed_nodes]
+        self.history = []
+        self.timestamp()
+
+    def change_state_accept(self, node_id, cust_clss):
+        """
+        Changes the state of the system when a customer is accepted.
+        """
+        if node_id-1 in self.observed_nodes:
+            state_index = self.observed_nodes.index(node_id-1)
+            self.state[state_index] += 1
+
+    def change_state_block(self, node_id, destination, cust_clss):
+        """
+        Changes the state of the system when a customer gets blocked.
+        """
+        pass
+
+    def change_state_release(self, node_id, destination, cust_clss, blocked):
+        """
+        Changes the state of the system when a customer is released.
+        """
+        if node_id-1 in self.observed_nodes:
+            state_index = self.observed_nodes.index(node_id-1)
+            self.state[state_index] -= 1
+
+    def hash_state(self):
+        """
+        Returns a hashable state.
+        """
+        return tuple(self.state)
+
+
+
+
+
 class NodeClassMatrix(StateTracker):
     """
     The node-class matrix tracker records the number of customers of each

--- a/ciw/trackers/state_tracker.py
+++ b/ciw/trackers/state_tracker.py
@@ -10,8 +10,7 @@ class StateTracker(object):
         """
         self.simulation = simulation
         self.state = None
-        self.history = []
-        self.timestamp()
+        self.history = [[self.simulation.current_time, self.hash_state()]]
 
     def change_state_accept(self, node_id, cust_clss):
         """
@@ -38,7 +37,9 @@ class StateTracker(object):
         return None
 
     def timestamp(self):
-        self.history.append([self.simulation.current_time, self.hash_state()])
+        current_hash_state = self.hash_state()
+        if current_hash_state != self.history[-1][1]:
+            self.history.append([self.simulation.current_time, current_hash_state])
 
     def state_probabilities(self, observation_period=(0, float("Inf"))):
         """
@@ -105,8 +106,7 @@ class SystemPopulation(StateTracker):
         """
         self.simulation = simulation
         self.state = 0
-        self.history = []
-        self.timestamp()
+        self.history = [[self.simulation.current_time, self.hash_state()]]
 
     def change_state_accept(self, node_id, cust_clss):
         """
@@ -149,8 +149,7 @@ class NodePopulation(StateTracker):
         self.simulation = simulation
         self.state = [0 for i in range(
             self.simulation.network.number_of_nodes)]
-        self.history = []
-        self.timestamp()
+        self.history = [[self.simulation.current_time, self.hash_state()]]
 
     def change_state_accept(self, node_id, cust_clss):
         """
@@ -199,8 +198,7 @@ class NodePopulationSubset(StateTracker):
         """
         self.simulation = simulation
         self.state = [0 for i in self.observed_nodes]
-        self.history = []
-        self.timestamp()
+        self.history = [[self.simulation.current_time, self.hash_state()]]
 
     def change_state_accept(self, node_id, cust_clss):
         """
@@ -254,8 +252,7 @@ class NodeClassMatrix(StateTracker):
         self.state = [[0 for cls in range(
             self.simulation.network.number_of_classes)] for i in range(
             self.simulation.network.number_of_nodes)]
-        self.history = []
-        self.timestamp()
+        self.history = [[self.simulation.current_time, self.hash_state()]]
 
     def change_state_accept(self, node_id, cust_clss):
         """
@@ -300,8 +297,7 @@ class NaiveBlocking(StateTracker):
         self.simulation = simulation
         self.state = [[0, 0] for i in range(
             self.simulation.network.number_of_nodes)]
-        self.history = []
-        self.timestamp()
+        self.history = [[self.simulation.current_time, self.hash_state()]]
 
     def change_state_accept(self, node_id, cust_clss):
         """
@@ -358,8 +354,7 @@ class MatrixBlocking(StateTracker):
             self.simulation.network.number_of_nodes)], [0 for i in range(
             self.simulation.network.number_of_nodes)]]
         self.increment = 1
-        self.history = []
-        self.timestamp()
+        self.history = [[self.simulation.current_time, self.hash_state()]]
 
     def change_state_accept(self, node_id, cust_clss):
         """

--- a/docs/Guides/state_trackers.rst
+++ b/docs/Guides/state_trackers.rst
@@ -50,5 +50,9 @@ From this we can obtain the proportion of time the system spend in each state::
 
 So the system was in state :code:`0` (no individuals in the system) 55.4% of the time, in state :code:`1` (one individual in the system) 24.7% of the time, state :code:`2` (two individuals in the system) 13.1% of the time, and state :code:`3` (three individuals in the system) 6.8% of the time.
 
+If a warm up and cool down time is required when calculating the state probabilities, we can put in an observation period. For example, if we with to find the proportion of time the system spend in each state, between dates :code:`50` and :code:`200`, then we can use the following::
+
+    >>> Q.statetracker.state_probabilities(observation_period=(50, 200)) # doctest:+SKIP
 
 Note that different trackers represent different states in different ways, see :ref:`refs-statetrackers` for a list of implemented trackers.
+

--- a/docs/Reference/state_trackers.rst
+++ b/docs/Reference/state_trackers.rst
@@ -8,6 +8,7 @@ Currently Ciw has the following state trackers:
 
 - :ref:`population`
 - :ref:`nodepop`
+- :ref:`nodepopsubset`
 - :ref:`nodeclssmatrix`
 - :ref:`naiveblock`
 - :ref:`matrixblock`
@@ -47,6 +48,24 @@ This denotes that there are two customers at the first node, no customers at the
 The Simulation object takes in the optional argument :code:`tracker` used as follows::
 
     >>> Q = ciw.Simulation(N, tracker=ciw.trackers.NodePopulation()) # doctest:+SKIP
+
+
+.. _nodepopsubset:
+
+--------------------------------
+The NodePopulationSubset Tracker
+--------------------------------
+
+The NodePopulationSubset Tracker, similar to the NodePopulation Tracker, records the number of customers at each node. However this allows users to only track a subset of the nodes in the system.
+States take the form of list of numbers. An example of tracking a three node queueing network is shown below::
+
+    (2, 0, 5)
+
+This denotes that there are two customers at the first observed node, no customers at the second observed node, and five customers at the third observed node.
+
+The Simulation object takes in the optional argument :code:`tracker`, which takes an argument :code:`observed_nodes` a list of node numbers to observe, used as follows (observing the first, second, and fifth nodes)::
+
+    >>> Q = ciw.Simulation(N, tracker=ciw.trackers.NodePopulationSubset([0, 1, 4])) # doctest:+SKIP
 
 
 .. _nodeclssmatrix:


### PR DESCRIPTION
+ Makes state tracking a little more efficient by not recording state changes with simply change to the same state.
+ Introduces the NodePopulationSubset tracker, that acts as a NodePopulation tracker but only for a subset of nodes.