### PR TITLE
Fix issue with empty lines on Windows, when export to CSV

### DIFF
--- a/ciw/simulation.py
+++ b/ciw/simulation.py
@@ -302,26 +302,25 @@ class Simulation(object):
         """
         root = os.getcwd()
         directory = os.path.join(root, file_name)
-        data_file = open('%s' % directory, 'w')
-        csv_wrtr = writer(data_file)
-        if headers:
-            csv_wrtr.writerow(['I.D. Number',
-                               'Customer Class',
-                               'Original Customer Class',
-                               'Node',
-                               'Arrival Date',
-                               'Waiting Time',
-                               'Service Start Date',
-                               'Service Time',
-                               'Service End Date',
-                               'Time Blocked',
-                               'Exit Date',
-                               'Destination',
-                               'Queue Size at Arrival',
-                               'Queue Size at Departure',
-                               'Server I.D.',
-                               'Record Type']),
-        records = self.get_all_records()
-        for row in records:
-            csv_wrtr.writerow(row)
-        data_file.close()
+        with open('%s' % directory, 'w', newline='', encoding="utf=8") as data_file:
+            csv_wrtr = writer(data_file)
+            if headers:
+                csv_wrtr.writerow(['I.D. Number',
+                                'Customer Class',
+                                'Original Customer Class',
+                                'Node',
+                                'Arrival Date',
+                                'Waiting Time',
+                                'Service Start Date',
+                                'Service Time',
+                                'Service End Date',
+                                'Time Blocked',
+                                'Exit Date',
+                                'Destination',
+                                'Queue Size at Arrival',
+                                'Queue Size at Departure',
+                                'Server I.D.',
+                                'Record Type']),
+            records = self.get_all_records()
+            for row in records:
+                csv_wrtr.writerow(row)

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -3,3 +3,4 @@ networkx>=2.3
 hypothesis==5.33.0
 tqdm==4.14.0
 coverage
+pandas>=1.3

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -3,4 +3,3 @@ networkx>=2.3
 hypothesis==5.33.0
 tqdm==4.14.0
 coverage
-pandas>=1.3


### PR DESCRIPTION
We must use `newline=''` with a CSV writer according [official documentation](https://docs.python.org/3.8/library/csv.html#csv.writer).

On Windows, `write_records_to_file` generates CSV file with empty lines.

I added context manager instead of explicit `close` file object and set encoding to the utf-8.