### PR TITLE
Fixed bug that tried to finish a blocked individual's service

### DIFF
--- a/ciw/node.py
+++ b/ciw/node.py
@@ -1,4 +1,5 @@
 from __future__ import division
+from pickle import FALSE
 from random import random
 import os
 from csv import writer
@@ -390,7 +391,7 @@ class Node(object):
         Finds the next individual that should now finish service.
         """
         next_individual_indices = [i for i, ind in enumerate(
-            self.all_individuals) if ind.service_end_date == self.next_event_date]
+            self.all_individuals) if ind.service_end_date == self.next_event_date if ind.is_blocked==False]
         if len(next_individual_indices) > 1:
             next_individual_index = random_choice(next_individual_indices)
         else:

--- a/ciw/tests/test_node.py
+++ b/ciw/tests/test_node.py
@@ -1575,3 +1575,17 @@ class TestNode(unittest.TestCase):
         self.assertEqual(r2.service_end_date, 8)
         self.assertEqual(r2.service_time, 3)
         self.assertEqual(r2.waiting_time, 4)
+
+    def test_do_not_repeat_finish_service_for_blocked_individuals(self):
+        N = ciw.create_network(
+            arrival_distributions=[ciw.dists.Sequential(sequence=[3.5, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]), ciw.dists.Sequential(sequence=[1.0, 1.0, float('inf')])],
+            service_distributions=[ciw.dists.Deterministic(value=1.0), ciw.dists.Deterministic(value=300.0)],
+            routing=[[0.0, 1.0],
+                     [0.0, 0.0]],
+            number_of_servers=[10, 2],
+            queue_capacities=[float('inf'), 0]
+        )
+        Q = ciw.Simulation(N)
+        Q.simulate_until_max_time(5)
+        expected_blocked_queue = [(1, 3), (1, 4), (1, 5), (1, 6), (1, 7), (1, 8), (1, 9)]
+        self.assertEqual(set(Q.nodes[2].blocked_queue), set(expected_blocked_queue))


### PR DESCRIPTION
When finding individuals to finish service, we do not check for blocked individuals anymore.