### PR TITLE
customer_class is hashable

### DIFF
--- a/ciw/individual.py
+++ b/ciw/individual.py
@@ -7,7 +7,7 @@ class Individual(object):
     ----------
     id_number : int
         A unique identifier for the individual.
-    customer_class : str, optional
+    customer_class : collections.abc.Hashable, optional
         The customer class to which the individual belongs (default is 'Customer').
     priority_class : int, optional
         The priority class of the individual (default is 0).
@@ -30,7 +30,7 @@ class Individual(object):
         Unique identifier for the individual.
     data_records : list
         A list to store additional data records.
-    customer_class : str
+    customer_class : collections.abc.Hashable
         The customer class to which the individual belongs.
     previous_class : str
         The previous customer class of the individual.


### PR DESCRIPTION
Because `customer_class` merely needs to be hashable and ordered, and there is no currently-supported typing for being ordered in Python, setting it to hashable seems like the closest typing to use for the current state. 

I have actually been using dataclasses with `@dataclass(order=True, frozen=True)` so that I can keep track of a variety of types of data that distinguish classes of patients based on their attributes. But I wouldn't want to make defining dataclasses a requirement.