### PR TITLE
Style of __repr__ in Individual

### DIFF
--- a/ciw/individual.py
+++ b/ciw/individual.py
@@ -103,4 +103,4 @@ class Individual(object):
     def __repr__(self):
         """Represents an Individual instance as a string.
         """
-        return f"Individual {self.id_number}"
+        return f"Individual(id_number={self.id_number})"


### PR DESCRIPTION
Personally, I find it more readable when the `__repr__` for classes like this have brackets around the information being displayed as object attributes and tells us what type of information that it is.

I.e.

The output

`Individual 1`

is simpler than

`Individual(id_number=1)`

but explicitly shows us what attribute is being communicated.