### PR TITLE
Change `!=` to `is not` in import_params.py

### DIFF
--- a/ciw/import_params.py
+++ b/ciw/import_params.py
@@ -43,23 +43,23 @@ def create_network(
         "service_distributions": service_distributions,
     }
 
-    if baulking_functions != None:
+    if baulking_functions is not None:
         params["baulking_functions"] = baulking_functions
-    if class_change_matrices != None:
+    if class_change_matrices is not None:
         params["class_change_matrices"] = class_change_matrices
     if class_change_time_distributions is not None:
         params["class_change_time_distributions"] = class_change_time_distributions
-    if priority_classes != None:
+    if priority_classes is not None:
         params["priority_classes"] = priority_classes
-    if queue_capacities != None:
+    if queue_capacities is not None:
         params["queue_capacities"] = queue_capacities
-    if routing != None:
+    if routing is not None:
         params["routing"] = routing
-    if batching_distributions != None:
+    if batching_distributions is not None:
         params["batching_distributions"] = batching_distributions
-    if ps_thresholds != None:
+    if ps_thresholds is not None:
         params["ps_thresholds"] = ps_thresholds
-    if server_priority_functions != None:
+    if server_priority_functions is not None:
         params["server_priority_functions"] = server_priority_functions
     if reneging_time_distributions is not None:
         params["reneging_time_distributions"] = reneging_time_distributions


### PR DESCRIPTION
In Python, the is not None construct is preferred over != None for several reasons:

    Identity Comparison vs. Value Comparison:
        is not is an identity comparison, which checks whether two objects refer to the same memory location.
        != is a value comparison, which checks whether the values of the objects are equal.

    None is a Singleton:
        None is a singleton object in Python, meaning there is only one instance of None in the entire program.
        Using is not None leverages the identity comparison and takes advantage of the fact that there is only one None object, making it more efficient than a value comparison.

    Consistency:
        Using is not None is more consistent with the recommended practice of using is and is not for checking against singletons (like None).

    Avoids Unintended Behavior:
        Value comparisons (!=) may behave unexpectedly when dealing with objects that override the __eq__ method, leading to potential pitfalls.
        Identity comparisons (is not) are safer in such cases, as they explicitly check for object identity.