### PR TITLE
Remove inheriting from `object` state_tracker.py

### DIFF
--- a/ciw/trackers/state_tracker.py
+++ b/ciw/trackers/state_tracker.py
@@ -1,4 +1,4 @@
-class StateTracker(object):
+class StateTracker:
     """
     A generic class to record system's state.
     """


### PR DESCRIPTION
Everything inherits from `type`.

https://realpython.com/inheritance-composition-python/