### PR TITLE
More docstrings in Degenerate distribution

### DIFF
--- a/ciw/dists/distributions.py
+++ b/ciw/dists/distributions.py
@@ -86,7 +86,7 @@ class CombinedDistribution(Distribution):
 
 class Uniform(Distribution):
     """
-    The Uniform distribution.
+    The continuous uniform distribution over an interval.
 
     Takes:
       - `lower` the lower bound
@@ -114,14 +114,22 @@ class Deterministic(Distribution):
     """
     The Deterministic distribution.
 
-    Takes:
-      - `value` the value to return
+    Notes
+    -----
+        This class samples from a degenerate distribution for a non-negative constant random variable.
+        This distribution is closely-related to the Dirac δ distribution.
     """
 
     def __init__(self, value):
+        """
+        Parameters
+        ----------
+        value
+            The value that is sampled.
+        """
         if value < 0.0:
             raise ValueError(
-                "Deterministic distribution must sample positive numbers only."
+                "Deterministic distribution must sample non-negative numbers only."
             )
         self.value = value
 


### PR DESCRIPTION
Added some notes on how this distribution is related to some other terminology:

- https://en.wikipedia.org/wiki/Dirac_delta_function
- https://en.wikipedia.org/wiki/Degenerate_distribution

Maybe this distribution should be called "Degenerate" rather than "Deterministic". Although it is deterministic, there are other deterministic cases that are non-constant like this. I'll leave that for a future discussion.

Also mentioned the non-negativity (rather than positivity) constraint in the value error.

