### PR TITLE
Feat add venv gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dist/
 *ciw/disciplines/.hypothesis*
 env/
 venv/
+.venv/

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist/
 *ciw/.hypothesis*
 *ciw/disciplines/.hypothesis*
 env/
+venv/


### PR DESCRIPTION
-  `venv` is often used for virtual environments.
- `.venv` provides support to the default name used when creating a virtual environment using `uv`.