### PR TITLE
Remove inheriting from object

### DIFF
--- a/ciw/deadlock/deadlock_detector.py
+++ b/ciw/deadlock/deadlock_detector.py
@@ -1,7 +1,7 @@
 import networkx as nx
 
 
-class NoDetection(object):
+class NoDetection:
     """
     A generic class for all deadlock detector classes to inherit from.
     Using this class is equivalent to having no deadlock detection


### PR DESCRIPTION
- It is no longer needed to inherit from `object`.