### PR TITLE
Shelter imports of type annotation types inside TYPE_CHECKING

### DIFF
--- a/ciw/dists/distributions.py
+++ b/ciw/dists/distributions.py
@@ -11,7 +11,11 @@ from random import (
     lognormvariate,
     weibullvariate,
 )
-from typing import List, NoReturn
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import List, NoReturn
 
 import numpy as np
 


### PR DESCRIPTION
- I am not sure if this will work since older versions of Python are still supported. Will try tho.