### PR TITLE
Use * instead of comprehension

### DIFF
--- a/ciw/import_params.py
+++ b/ciw/import_params.py
@@ -78,7 +78,7 @@ def create_network_from_dictionary(params_input):
     number_of_classes = params["number_of_classes"]
     number_of_nodes = params["number_of_nodes"]
     if isinstance(params["priority_classes"], dict):
-        preempt_priorities = [False for _ in range(number_of_nodes)]
+        preempt_priorities = [False] * number_of_nodes
     if isinstance(params["priority_classes"], tuple):
         preempt_priorities = params["priority_classes"][1]
         params["priority_classes"] = {
@@ -87,7 +87,7 @@ def create_network_from_dictionary(params_input):
         }
     class_change_matrices = params.get(
         "class_change_matrices",
-        [None for nd in range(number_of_nodes)],
+        [None] * number_of_nodes,
     )
     class_change_time_distributions = {clss2: {clss1: None for clss1 in params['customer_class_names']} for clss2 in params['customer_class_names']}
     if 'class_change_time_distributions' in params:
@@ -165,28 +165,29 @@ def fill_out_dictionary(params):
     class_names = sorted(params["arrival_distributions"].keys())
     params["customer_class_names"] = class_names
 
+    number_of_nodes = len(params["number_of_servers"])
     default_dict = {
         "name": "Simulation",
         "routing": {class_name: routing.TransitionMatrix(transition_matrix=[[0.0]]) for class_name in class_names},
-        "number_of_nodes": len(params["number_of_servers"]),
+        "number_of_nodes": number_of_nodes,
         "number_of_classes": len(class_names),
-        "queue_capacities": [float("inf") for _ in range(len(params["number_of_servers"]))],
+        "queue_capacities": [float("inf")] * number_of_nodes, 
         "priority_classes": {class_name: 0 for class_name in class_names},
-        "baulking_functions": {class_name: [None for _ in range(len(params["number_of_servers"]))]for class_name in class_names},
+        "baulking_functions": {class_name: [None] * number_of_nodes for class_name in class_names},
         "batching_distributions": {class_name: [
-                ciw.dists.Deterministic(1) for _ in range(len(params["number_of_servers"]))
-            ] for class_name in class_names},
-        "ps_thresholds": [1 for _ in range(len(params["number_of_servers"]))],
+                ciw.dists.Deterministic(1)
+        ] * number_of_nodes for class_name in class_names},
+        "ps_thresholds": [1] * number_of_nodes,
         "server_priority_functions": [
-            None for _ in range(len(params["number_of_servers"]))
-        ],
+            None
+        ] * number_of_nodes,
         "reneging_time_distributions": {
-            class_name: [None for _ in range(len(params["number_of_servers"]))]
+            class_name: [None] * number_of_nodes
             for class_name in class_names
         },
         "service_disciplines": [
-            ciw.disciplines.FIFO for _ in range(len(params["number_of_servers"]))
-        ],
+            ciw.disciplines.FIFO
+        ] * number_of_nodes,
         "system_capacity": float('inf')
     }
 

--- a/ciw/import_params.py
+++ b/ciw/import_params.py
@@ -185,9 +185,7 @@ def fill_out_dictionary(params):
             class_name: [None] * number_of_nodes
             for class_name in class_names
         },
-        "service_disciplines": [
-            ciw.disciplines.FIFO
-        ] * number_of_nodes,
+        "service_disciplines": [ciw.disciplines.FIFO for _ in range(number_of_nodes)],
         "system_capacity": float('inf')
     }
 


### PR DESCRIPTION
- After tinkering with `timeit` I noticed that usually it is faster to multiply a singleton list by a desired constant than it is to construct and use the `range` iterator. 
- In one case I noticed a 3X improvement.
- This is suitable for constructing a new list containing the same constant value. 